### PR TITLE
Pocket-ID - Update Port Target

### DIFF
--- a/templates/pocket_id.xml
+++ b/templates/pocket_id.xml
@@ -30,7 +30,7 @@
 
         Initial release
     </Changes>
-    <Config Name="WebUI" Target="3000" Default="3000" Mode="tcp" Description="Container Port: 3000" Type="Port" Display="always-hide" Required="true" Mask="false">3000</Config>
+    <Config Name="WebUI" Target="80" Default="3000" Mode="tcp" Description="Port to access WebUI: 3000" Type="Port" Display="always-hide" Required="true" Mask="false">3000</Config>
     <Config Name="Public App URL" Target="PUBLIC_APP_URL" Default="http://localhost" Description="The URL where you will access the app. Recommended to change from default." Type="Variable" Display="always-hide" Required="true" Mask="false">http://localhost</Config>
     <Config Name="Data Path" Target="/app/backend/data" Default="/mnt/user/appdata/pocket-id/data" Mode="rw" Description="Data directory" Type="Path" Display="advanced-hide" Required="true" Mask="false">/mnt/user/appdata/pocket-id/data</Config>
     <Config Name="Database Path" Target="DB_PATH" Default="data/pocket-id.db" Description="Path inside the container to the SQLite database file" Type="Variable" Display="advanced-hide" Required="true" Mask="false">data/pocket-id.db</Config>

--- a/templates/pocket_id.xml
+++ b/templates/pocket_id.xml
@@ -13,7 +13,7 @@
     </Branch>
     <Network>bridge</Network>
     <Privileged>false</Privileged>
-    <WebUI>http://[IP]:[PORT:3000]/</WebUI>
+    <WebUI>http://[IP]:[PORT:80]/</WebUI>
     <Support>https://github.com/stonith404/pocket-id/issues</Support>
     <Project>https://github.com/stonith404/pocket-id</Project>
     <Overview>A simple OIDC provider that allows users to authenticate with their passkeys to your services.</Overview>

--- a/templates/pocket_id.xml
+++ b/templates/pocket_id.xml
@@ -26,11 +26,15 @@
         <WebPage>https://github.com/nwithan8</WebPage>
     </Maintainer>
     <Changes>
+        ### 2024-08-21
+
+        Fix port mapping
+
         ### 2024-08-12
 
         Initial release
     </Changes>
-    <Config Name="WebUI" Target="80" Default="3000" Mode="tcp" Description="Port to access WebUI: 3000" Type="Port" Display="always-hide" Required="true" Mask="false">3000</Config>
+    <Config Name="WebUI" Target="80" Default="3000" Mode="tcp" Description="Port to access WebUI" Type="Port" Display="always-hide" Required="true" Mask="false">3000</Config>
     <Config Name="Public App URL" Target="PUBLIC_APP_URL" Default="http://localhost" Description="The URL where you will access the app. Recommended to change from default." Type="Variable" Display="always-hide" Required="true" Mask="false">http://localhost</Config>
     <Config Name="Data Path" Target="/app/backend/data" Default="/mnt/user/appdata/pocket-id/data" Mode="rw" Description="Data directory" Type="Path" Display="advanced-hide" Required="true" Mask="false">/mnt/user/appdata/pocket-id/data</Config>
     <Config Name="Database Path" Target="DB_PATH" Default="data/pocket-id.db" Description="Path inside the container to the SQLite database file" Type="Variable" Display="advanced-hide" Required="true" Mask="false">data/pocket-id.db</Config>


### PR DESCRIPTION
Currently, when attempting to utilise this template, the user is unable to perform any actions, and a number of pages come back as 404; this resolves that by using the caddy server running in the container, which is the intended ingress point.

Ref: https://github.com/stonith404/pocket-id/issues/11