### PR TITLE
fix: don't require ports

### DIFF
--- a/templates/anon_addy.xml
+++ b/templates/anon_addy.xml
@@ -31,8 +31,8 @@
     <Requires>
         Requires a separate MySQL and Redis server. See documentation: https://github.com/anonaddy/anonaddy/blob/master/SELF-HOSTING.md
     </Requires>
-    <Config Name="Web UI Port" Target="8000" Default="8000" Mode="tcp" Description="Container Port: 8000" Type="Port" Display="always-hide" Required="true" Mask="false">8000</Config>
-    <Config Name="SMTP Email Port" Target="25" Default="25" Mode="tcp" Description="Container Port: 25" Type="Port" Display="always-hide" Required="true" Mask="false">25</Config>
+    <Config Name="Web UI Port" Target="8000" Default="8000" Mode="tcp" Description="Container Port: 8000" Type="Port" Display="always-hide" Required="false" Mask="false">8000</Config>
+    <Config Name="SMTP Email Port" Target="25" Default="25" Mode="tcp" Description="Container Port: 25" Type="Port" Display="always-hide" Required="false" Mask="false">25</Config>
     <Config Name="App URL" Target="APP_URL" Default="http://localhost:8000/" Description="The URL to the AnonAddy server" Type="Variable" Display="always-hide" Required="true" Mask="false">http://localhost:8000/</Config>
     <Config Name="MySQL - Host" Target="DB_HOST" Default="localhost" Description="The host for the MySQL database connection" Type="Variable" Display="always-hide" Required="false" Mask="false">localhost</Config>
     <Config Name="MySQL - Port" Target="DB_PORT" Default="3306" Description="The port for the MySQL database connection" Type="Variable" Display="always-hide" Required="false" Mask="false">3306</Config>

--- a/templates/anything_llm.xml
+++ b/templates/anything_llm.xml
@@ -44,7 +44,7 @@
         Initial release
     </Changes>
     <ExtraParams>--cap-add SYS_ADMIN</ExtraParams>
-    <Config Name="WebUI" Target="3001" Default="3001" Mode="tcp" Description="Container Port: 3001" Type="Port" Display="always" Required="true" Mask="false">3001</Config>
+    <Config Name="WebUI" Target="3001" Default="3001" Mode="tcp" Description="Container Port: 3001" Type="Port" Display="always" Required="false" Mask="false">3001</Config>
     <Config Name="Environment File Path" Target="/app/server/.env" Default="/mnt/user/appdata/anythingllm/.env" Mode="rw" Description="Path to the environmental variable file. File must exist before running!" Type="Path" Display="advanced" Required="true" Mask="false">/mnt/user/appdata/anythingllm/.env</Config>
     <Config Name="In-container storage path" Target="STORAGE_DIR" Default="/app/server/storage" Description="In-container storage location. Do not change!" Type="Variable" Display="advanced" Required="true" Mask="false">/app/server/storage</Config>
     <Config Name="Storage Path" Target="/app/server/storage" Default="/mnt/user/appdata/anythingllm" Mode="rw" Description="Storage for databases and file storage" Type="Path" Display="advanced" Required="true" Mask="false">/mnt/user/appdata/anythingllm</Config>

--- a/templates/aqtion_server_3team.xml
+++ b/templates/aqtion_server_3team.xml
@@ -27,7 +27,7 @@
         [br]
         Requires a Message of the Day text file passed in the Message of the Day File configuration: https://github.com/actionquake/distrib/blob/main/server/3team1.motd
     </Requires>
-    <Config Name="Server Port - TCP" Target="27940" Default="27940" Mode="tcp" Description="Container Port: 27940" Type="Port" Display="always-hide" Required="true" Mask="false">27940</Config>
+    <Config Name="Server Port - TCP" Target="27940" Default="27940" Mode="tcp" Description="Container Port: 27940" Type="Port" Display="always-hide" Required="false" Mask="false">27940</Config>
     <Config Name="Server Port - UDP" Target="27940" Default="27940" Mode="udp" Description="Container Port: 27940" Type="Port" Display="always-hide" Required="true" Mask="false">27940</Config>
     <Config Name="Server Port" Target="PORT" Default="27940" Description="Internal server port. Must match port above." Type="Variable" Display="always-hide" Required="true" Mask="false">27940</Config>
     <Config Name="Server Name" Target="HOSTNAME" Default="AQtion 3Team Server" Description="Hostname of server in server browser" Type="Variable" Display="always-hide" Required="true" Mask="false">AQtion 3Team Server</Config>

--- a/templates/aqtion_server_dm.xml
+++ b/templates/aqtion_server_dm.xml
@@ -27,7 +27,7 @@
         [br]
         Requires a Message of the Day text file passed in the Message of the Day File configuration: https://github.com/actionquake/distrib/blob/main/server/dm1.motd
     </Requires>
-    <Config Name="Server Port - TCP" Target="27940" Default="27940" Mode="tcp" Description="Container Port: 27940" Type="Port" Display="always-hide" Required="true" Mask="false">27940</Config>
+    <Config Name="Server Port - TCP" Target="27940" Default="27940" Mode="tcp" Description="Container Port: 27940" Type="Port" Display="always-hide" Required="false" Mask="false">27940</Config>
     <Config Name="Server Port - UDP" Target="27940" Default="27940" Mode="udp" Description="Container Port: 27940" Type="Port" Display="always-hide" Required="true" Mask="false">27940</Config>
     <Config Name="Server Port" Target="PORT" Default="27940" Description="Internal server port. Must match port above." Type="Variable" Display="always-hide" Required="true" Mask="false">27940</Config>
     <Config Name="Server Name" Target="HOSTNAME" Default="AQtion Deathmatch Server" Description="Hostname of server in server browser" Type="Variable" Display="always-hide" Required="true" Mask="false">AQtion Deathmatch Server</Config>

--- a/templates/aqtion_server_tdm.xml
+++ b/templates/aqtion_server_tdm.xml
@@ -27,7 +27,7 @@
         [br]
         Requires a Message of the Day text file passed in the Message of the Day File configuration: https://github.com/actionquake/distrib/blob/main/server/tdm1.motd
     </Requires>
-    <Config Name="Server Port - TCP" Target="27940" Default="27940" Mode="tcp" Description="Container Port: 27940" Type="Port" Display="always-hide" Required="true" Mask="false">27940</Config>
+    <Config Name="Server Port - TCP" Target="27940" Default="27940" Mode="tcp" Description="Container Port: 27940" Type="Port" Display="always-hide" Required="false" Mask="false">27940</Config>
     <Config Name="Server Port - UDP" Target="27940" Default="27940" Mode="udp" Description="Container Port: 27940" Type="Port" Display="always-hide" Required="true" Mask="false">27940</Config>
     <Config Name="Server Port" Target="PORT" Default="27940" Description="Internal server port. Must match port above." Type="Variable" Display="always-hide" Required="true" Mask="false">27940</Config>
     <Config Name="Server Name" Target="HOSTNAME" Default="AQtion TDM Server" Description="Hostname of server in server browser" Type="Variable" Display="always-hide" Required="true" Mask="false">AQtion TDM Server</Config>

--- a/templates/aqtion_server_tp.xml
+++ b/templates/aqtion_server_tp.xml
@@ -27,7 +27,7 @@
         [br]
         Requires a Message of the Day text file passed in the Message of the Day File configuration: https://github.com/actionquake/distrib/blob/main/server/tp1.motd
     </Requires>
-    <Config Name="Server Port - TCP" Target="27940" Default="27940" Mode="tcp" Description="Container Port: 27940" Type="Port" Display="always-hide" Required="true" Mask="false">27940</Config>
+    <Config Name="Server Port - TCP" Target="27940" Default="27940" Mode="tcp" Description="Container Port: 27940" Type="Port" Display="always-hide" Required="false" Mask="false">27940</Config>
     <Config Name="Server Port - UDP" Target="27940" Default="27940" Mode="udp" Description="Container Port: 27940" Type="Port" Display="always-hide" Required="true" Mask="false">27940</Config>
     <Config Name="Server Port" Target="PORT" Default="27940" Description="Internal server port. Must match port above." Type="Variable" Display="always-hide" Required="true" Mask="false">27940</Config>
     <Config Name="Server Name" Target="HOSTNAME" Default="AQtion Teamplay Server" Description="Hostname of server in server browser" Type="Variable" Display="always-hide" Required="true" Mask="false">AQtion Teamplay Server</Config>

--- a/templates/araa.xml
+++ b/templates/araa.xml
@@ -27,7 +27,7 @@
 
         Initial release
     </Changes>
-    <Config Name="Web UI Port" Target="8000" Default="8000" Mode="tcp" Description="Container Port: 8000" Type="Port" Display="always-hide" Required="true" Mask="false">8000</Config>
+    <Config Name="Web UI Port" Target="8000" Default="8000" Mode="tcp" Description="Container Port: 8000" Type="Port" Display="always-hide" Required="false" Mask="false">8000</Config>
     <Config Name="Customization - Shebang" Target="SHEBANG" Default="!" Description="" Type="Variable" Display="always-hide" Required="true" Mask="false">!</Config>
     <Config Name="Customization - Theme" Target="DEFAULT_THEME" Default="dark_default|dark_blur" Description="Default theme to use" Type="Variable" Display="always-hide" Required="true" Mask="false"/>
     <Config Name="Customization - Method" Target="DEFAULT_METHOD" Default="GET" Description="Default method to use" Type="Variable" Display="always-hide" Required="true" Mask="false"/>

--- a/templates/automatic1111.xml
+++ b/templates/automatic1111.xml
@@ -34,7 +34,7 @@
         This is a web UI for Stable Diffusion and uses a Docker image which is several gigabytes. If you receive a "no space left on device" warning during installation, please increase the vDisk size in your Docker settings.
     </Requires>
     <ExtraParams>--gpus=all</ExtraParams>
-    <Config Name="Web UI Port" Target="7860" Default="7860" Mode="tcp" Description="Container Port: 7860" Type="Port" Display="always" Required="true" Mask="false">7860</Config>
+    <Config Name="Web UI Port" Target="7860" Default="7860" Mode="tcp" Description="Container Port: 7860" Type="Port" Display="always" Required="false" Mask="false">7860</Config>
     <Config Name="Configuration data" Target="/data" Default="/mnt/user/appdata/automatic1111/data" Mode="rw" Description="Path to configuration data" Type="Path" Display="advanced" Required="true" Mask="false">/mnt/user/appdata/automatic1111/data</Config>
     <Config Name="Output directory" Target="/output" Default="/mnt/user/appdata/automatic1111/output" Mode="rw" Description="Path to output (saved images) directory" Type="Path" Display="advanced" Required="true" Mask="false">/mnt/user/appdata/automatic1111/output</Config>
     <Config Name="Nvidia Visible Devices" Target="NVIDIA_VISIBLE_DEVICES" Default="all" Mode="" Description="Nvidia Visible Devices" Type="Variable" Display="advanced-hide" Required="false" Mask="false"/>

--- a/templates/automatisch_gui.xml
+++ b/templates/automatisch_gui.xml
@@ -32,7 +32,7 @@
         [br]
         This is the web interface for Automatisch. A separate worker container is required to run the application.
     </Requires>
-    <Config Name="Web UI Port" Target="3000" Default="3000" Mode="tcp" Description="Access web interface" Type="Port" Display="always-hide" Required="true" Mask="false">3000</Config>
+    <Config Name="Web UI Port" Target="3000" Default="3000" Mode="tcp" Description="Access web interface" Type="Port" Display="always-hide" Required="false" Mask="false">3000</Config>
     <Config Name="Web UI URL" Target="WEB_APP_URL" Default="http://localhost:3000" Description="URL for the web interface. Replace with local IP or domain." Type="Variable" Display="always-hide" Required="true" Mask="false">http://localhost:3000</Config>
     <Config Name="Redis - Host" Target="REDIS_HOST" Default="localhost" Description="Host for Redis server" Type="Variable" Display="always-hide" Required="true" Mask="false">localhost</Config>
     <Config Name="Redis - Port" Target="REDIS_PORT" Default="6379" Description="Port for Redis server" Type="Variable" Display="always-hide" Required="true" Mask="false">6379</Config>

--- a/templates/avatar.xml
+++ b/templates/avatar.xml
@@ -42,6 +42,6 @@
     <Requires>
         Expects a `default.json` file in the "Config Path": https://raw.githubusercontent.com/nwithan8/unraid_templates/master/ref/avatar/default.json
     </Requires>
-    <Config Name="Web UI Port" Target="9000" Default="9000" Mode="tcp" Description="Container Port: 9000" Type="Port" Display="always-hide" Required="true" Mask="false">9000</Config>
+    <Config Name="Web UI Port" Target="9000" Default="9000" Mode="tcp" Description="Container Port: 9000" Type="Port" Display="always-hide" Required="false" Mask="false">9000</Config>
     <Config Name="Config Path" Target="/app/config" Default="/mnt/user/appdata/avatar/config" Description="Path to store configuration files" Mode="rw" Type="Path" Display="advanced-hide" Required="true" Mask="false">/mnt/user/appdata/avatar/config</Config>
 </Container>

--- a/templates/axym_reader.xml
+++ b/templates/axym_reader.xml
@@ -27,5 +27,5 @@
 
         Initial release
     </Changes>
-    <Config Name="WebUI" Target="8080" Default="8080" Mode="tcp" Description="Container Port: 8080" Type="Port" Display="always" Required="true" Mask="false">8080</Config>
+    <Config Name="WebUI" Target="8080" Default="8080" Mode="tcp" Description="Container Port: 8080" Type="Port" Display="always" Required="false" Mask="false">8080</Config>
 </Container>

--- a/templates/big_agi.xml
+++ b/templates/big_agi.xml
@@ -33,5 +33,5 @@
 
         Initial release
     </Changes>
-    <Config Name="WebUI" Target="3000" Default="3000" Mode="tcp" Description="Container Port: 3000" Type="Port" Display="always" Required="true" Mask="false">3000</Config>
+    <Config Name="WebUI" Target="3000" Default="3000" Mode="tcp" Description="Container Port: 3000" Type="Port" Display="always" Required="false" Mask="false">3000</Config>
 </Container>

--- a/templates/bliss.xml
+++ b/templates/bliss.xml
@@ -30,8 +30,8 @@
     <Requires>
         Due to a permissions issue, you must create the Configuration Data path before starting the container. Open a terminal and run the following command: "mkdir -p /mnt/user/appdata/bliss/config"
     </Requires>
-    <Config Name="Web UI Port" Target="3220" Default="3220" Mode="tcp" Description="Container Port: 3220" Type="Port" Display="always-hide" Required="true" Mask="false">3220</Config>
-    <Config Name="Services Port" Target="3221" Default="3221" Mode="tcp" Description="Container Port: 3221" Type="Port" Display="always-hide" Required="true" Mask="false">3221</Config>
+    <Config Name="Web UI Port" Target="3220" Default="3220" Mode="tcp" Description="Container Port: 3220" Type="Port" Display="always-hide" Required="false" Mask="false">3220</Config>
+    <Config Name="Services Port" Target="3221" Default="3221" Mode="tcp" Description="Container Port: 3221" Type="Port" Display="always-hide" Required="false" Mask="false">3221</Config>
     <Config Name="Music Files" Target="/music" Default="" Mode="rw" Description="Path to music files" Type="Path" Display="always-hide" Required="true" Mask="false" />
     <Config Name="Configuration Data" Target="/config" Default="/mnt/user/appdata/bliss/config" Mode="rw" Description="Path to configuration data" Type="Path" Display="advanced-hide" Required="true" Mask="false">/mnt/user/appdata/bliss/config</Config>
     <Config Name="PUID" Target="PUID" Default="099" Description="" Type="Variable" Display="advanced" Required="true" Mask="false">099</Config>

--- a/templates/briefkasten.xml
+++ b/templates/briefkasten.xml
@@ -31,7 +31,7 @@
 
         Initial release
     </Changes>
-    <Config Name="Web UI Port" Target="3000" Default="3000" Mode="tcp" Description="Container Port: 3000" Type="Port" Display="always" Required="true" Mask="false">3000</Config>
+    <Config Name="Web UI Port" Target="3000" Default="3000" Mode="tcp" Description="Container Port: 3000" Type="Port" Display="always" Required="false" Mask="false">3000</Config>
     <Config Name="Database Connection URL" Target="DATABASE_URL" Default="postgresql://user:password@host:port/dbname" Description="Connection URL for the Postgres database" Type="Variable" Display="always" Required="true" Mask="false"/>
     <Config Name="Authentication Secret" Target="NEXTAUTH_SECRET" Default="" Description="Secret to use for authentication. Run `openssl rand -hex 32` to generate." Type="Variable" Display="always" Required="false" Mask="true"/>
     <Config Name="GitHub - Client ID" Target="GITHUB_ID" Default="" Description="GitHub OAuth Client ID" Type="Variable" Display="always" Required="false" Mask="false"/>

--- a/templates/cal_com.xml
+++ b/templates/cal_com.xml
@@ -31,7 +31,7 @@
     <Requires>
         Requires a separate PostgreSQL database container
     </Requires>
-    <Config Name="Web UI Port" Target="3000" Default="3000" Mode="tcp" Description="Container Port: 3000" Type="Port" Display="always-hide" Required="true" Mask="false">3000</Config>
+    <Config Name="Web UI Port" Target="3000" Default="3000" Mode="tcp" Description="Container Port: 3000" Type="Port" Display="always-hide" Required="false" Mask="false">3000</Config>
     <Config Name="Web URL" Target="NEXT_PUBLIC_WEBAPP_URL" Default="http://localhost:3000" Description="The base URL for the webapp. Replace localhost with IP address" Type="Variable" Display="always-hide" Required="true" Mask="false">http://localhost:3000</Config>
     <Config Name="API URL" Target="NEXT_PUBLIC_API_V2_URL" Default="http://localhost:5555/api/v2" Description="The base URL for the API. Replace localhost with IP address" Type="Variable" Display="always-hide" Required="true" Mask="false">http://localhost:5555/api/v2</Config>
     <Config Name="Web Secret" Target="NEXTAUTH_SECRET" Default="" Description="Secret for the webapp. Use `openssl rand -base64 32` to generate." Type="Variable" Display="always-hide" Required="true" Mask="true"/>

--- a/templates/cal_com_studio.xml
+++ b/templates/cal_com_studio.xml
@@ -32,7 +32,7 @@
         Requires a separate PostgreSQL database container
     </Requires>
     <PostArgs>npx prisma studio</PostArgs>
-    <Config Name="Web UI Port" Target="5555" Default="5555" Mode="tcp" Description="Container Port: 5555" Type="Port" Display="always-hide" Required="true" Mask="false">5555</Config>
+    <Config Name="Web UI Port" Target="5555" Default="5555" Mode="tcp" Description="Container Port: 5555" Type="Port" Display="always-hide" Required="false" Mask="false">5555</Config>
     <Config Name="Web URL" Target="NEXT_PUBLIC_WEBAPP_URL" Default="http://localhost:3000" Description="The base URL for the webapp. Replace localhost with IP address" Type="Variable" Display="always-hide" Required="true" Mask="false">http://localhost:3000</Config>
     <Config Name="API URL" Target="NEXT_PUBLIC_API_V2_URL" Default="http://localhost:5555/api/v2" Description="The base URL for the API. Replace localhost with IP address" Type="Variable" Display="always-hide" Required="true" Mask="false">http://localhost:5555/api/v2</Config>
     <Config Name="Web Secret" Target="NEXTAUTH_SECRET" Default="" Description="Secret for the webapp. Use `openssl rand -base64 32` to generate." Type="Variable" Display="always-hide" Required="true" Mask="true"/>

--- a/templates/castopod.xml
+++ b/templates/castopod.xml
@@ -40,7 +40,7 @@
     <Requires>
         Requires separate MariaDB and Redis databases.
     </Requires>
-    <Config Name="Web UI Port" Target="8000" Default="8000" Mode="tcp" Description="Container Port: 8000" Type="Port" Display="always-hide" Required="true" Mask="false">8000</Config>
+    <Config Name="Web UI Port" Target="8000" Default="8000" Mode="tcp" Description="Container Port: 8000" Type="Port" Display="always-hide" Required="false" Mask="false">8000</Config>
     <Config Name="App URL" Target="CP_BASEURL" Default="http://localhost:8000" Description="URL of Castopod. Change to IP or domain." Type="Variable" Display="always-hide" Required="true" Mask="false">http://localhost:8000</Config>
     <Config Name="Analytics Salt" Target="CP_ANALYTICS_SALT" Default="" Description="Salt for analytics" Type="Variable" Display="always-hide" Required="true" Mask="true"/>
     <Config Name="MariaDB - Host" Target="CP_DATABASE_HOSTNAME" Default="" Description="Hostname of MariaDB" Type="Variable" Display="always-hide" Required="true" Mask="false"/>

--- a/templates/channels_dvr.xml
+++ b/templates/channels_dvr.xml
@@ -25,7 +25,7 @@
         Container requires a subscription to Channels DVR. To log in, establish an SSH tunnel to the container (e.g. `ssh -L8089:localhost:8089 root@unraid_ip`) and visit http://localhost:8089 in your browser.
     </Requires>
     <Config Name="DVR Storage" Target="/shares/DVR" Default="" Mode="rw" Description="Path to DVR recordings storage" Type="Path" Display="always" Required="true" Mask="false"/>
-    <Config Name="WebUI" Target="8089" Default="8089" Mode="tcp" Description="Container Port: 8089" Type="Port" Display="always" Required="true" Mask="false">8089</Config>
+    <Config Name="WebUI" Target="8089" Default="8089" Mode="tcp" Description="Container Port: 8089" Type="Port" Display="always" Required="false" Mask="false">8089</Config>
     <Config Name="Config Path" Target="/channels-dvr" Default="/mnt/user/appdata/channels-dvr" Mode="rw" Description="Path to config storage" Type="Path" Dislay="advanced" Required="true" Mask="false">/mnt/user/appdata/channels-dvr</Config>
     <Config Name="PUID" Target="PUID" Default="099" Description="" Type="Variable" Display="advanced" Required="true" Mask="false">099</Config>
     <Config Name="PGID" Target="PGID" Default="100" Description="" Type="Variable" Display="advanced" Required="true" Mask="false">100</Config>

--- a/templates/charm.xml
+++ b/templates/charm.xml
@@ -29,10 +29,10 @@
 
         Initial release
     </Changes>
-    <Config Name="SSH Port" Target="35353" Default="" Mode="tcp" Description="Container Port: 35353" Type="Port" Display="always" Required="true" Mask="false">35353</Config>
-    <Config Name="HTTP Port" Target="35354" Default="" Mode="tcp" Description="Container Port: 35354" Type="Port" Display="always" Required="true" Mask="false">35354</Config>
-    <Config Name="Stats Port" Target="35355" Default="" Mode="tcp" Description="Container Port: 35355" Type="Port" Display="always" Required="true" Mask="false">35355</Config>
-    <Config Name="Health Port" Target="35356" Default="" Mode="tcp" Description="Container Port: 35356" Type="Port" Display="always" Required="true" Mask="false">35356</Config>
+    <Config Name="SSH Port" Target="35353" Default="" Mode="tcp" Description="Container Port: 35353" Type="Port" Display="always" Required="false" Mask="false">35353</Config>
+    <Config Name="HTTP Port" Target="35354" Default="" Mode="tcp" Description="Container Port: 35354" Type="Port" Display="always" Required="false" Mask="false">35354</Config>
+    <Config Name="Stats Port" Target="35355" Default="" Mode="tcp" Description="Container Port: 35355" Type="Port" Display="always" Required="false" Mask="false">35355</Config>
+    <Config Name="Health Port" Target="35356" Default="" Mode="tcp" Description="Container Port: 35356" Type="Port" Display="always" Required="false" Mask="false">35356</Config>
     <Config Name="Max storage per user" Target="CHARM_SERVER_USER_MAX_STORAGE" Default="0" Description="Maximum storage per user. 0 for no limit" Type="Variable" Display="advanced" Required="false" Mask="false">0</Config>
     <Config Name="Data Path" Target="/data" Default="/mnt/user/appdata/charm" Mode="rw" Description="Storage for databases and file storage" Type="Path" Display="advanced" Required="true" Mask="false">/mnt/user/appdata/charm</Config>
 </Container>

--- a/templates/chevereto.xml
+++ b/templates/chevereto.xml
@@ -31,7 +31,7 @@
 
         Initial release
     </Changes>
-    <Config Name="WebUI" Target="80" Default="8999" Mode="tcp" Description="Container Port: 80" Type="Port" Display="always" Required="true" Mask="false">8999</Config>
+    <Config Name="WebUI" Target="80" Default="8999" Mode="tcp" Description="Container Port: 80" Type="Port" Display="always" Required="false" Mask="false">8999</Config>
     <Config Name="Images path" Target="/var/www/html/images" Default="/mnt/user/appdata/chevereto/images" Mode="rw" Description="Images path" Type="Path" Display="always" Required="true" Mask="false">/mnt/user/appdata/chevereto/images</Config>
     <Config Name="MariaDB Host" Target="CHEVERETO_DB_HOST" Default="mariadb" Description="MariaDB Hostname" Type="Variable" Display="always" Required="true" Mask="false"/>
     <Config Name="MariaDB Port" Target="CHEVERETO_DB_PORT" Default="3306" Description="MariaDB Port" Type="Variable" Display="always" Required="true" Mask="false"/>

--- a/templates/christmas_community.xml
+++ b/templates/christmas_community.xml
@@ -36,7 +36,7 @@
 
         Initial release
     </Changes>
-    <Config Name="Web UI Port" Target="80" Default="8080" Mode="tcp" Description="Container Port: 80" Type="Port" Display="always" Required="true" Mask="false">8080</Config>
+    <Config Name="Web UI Port" Target="80" Default="8080" Mode="tcp" Description="Container Port: 80" Type="Port" Display="always" Required="false" Mask="false">8080</Config>
     <Config Name="Enable Public Lists" Target="LISTS_PUBLIC" Default="false|true" Description="Allow viewing wishlists without logging in" Type="Variable" Display="always" Required="true" Mask="false"/>
     <Config Name="Enable Single List Mode" Target="SINGLE_LIST" Default="false|true" Description="Limit to only one list (only the admin account's list). Useful for weddings, birthdays, etc." Type="Variable" Display="always" Required="true" Mask="false"/>
     <Config Name="Use Table Mode" Target="TABLE" Default="true|false" Description="true - Use table layout, false - use legacy card layout" Type="Variable" Display="always" Required="true" Mask="false"/>

--- a/templates/clipcascade.xml
+++ b/templates/clipcascade.xml
@@ -27,7 +27,7 @@
 
         Initial release
     </Changes>
-    <Config Name="Web UI Port" Target="8080" Default="8080" Mode="tcp" Description="Container Port: 8080" Type="Port" Display="always" Required="true" Mask="false">8080</Config>
+    <Config Name="Web UI Port" Target="8080" Default="8080" Mode="tcp" Description="Container Port: 8080" Type="Port" Display="always" Required="false" Mask="false">8080</Config>
     <Config Name="Username" Target="CC_USERNAME" Default="" Description="Username for sync" Type="Variable" Display="always" Required="true" Mask="false"/>
     <Config Name="Password" Target="CC_PASSWORD" Default="" Description="Password for sync" Type="Variable" Display="always" Required="true" Mask="true"/>
     <Config Name="Max Message Size" Target="CC_MAX_MESSAGE_SIZE" Default="1" Description="Maximum message size, in MB. Recommend less than 25 for desktop, approx. 1 for mobile" Type="Variable" Display="always" Required="true" Mask="false">1</Config>

--- a/templates/convertx.xml
+++ b/templates/convertx.xml
@@ -26,7 +26,7 @@
 
         Initial release
     </Changes>
-    <Config Name="Web UI Port" Target="3000" Default="3000" Mode="tcp" Description="Container Port: 3000" Type="Port" Display="always-hide" Required="true" Mask="false">3000</Config>
+    <Config Name="Web UI Port" Target="3000" Default="3000" Mode="tcp" Description="Container Port: 3000" Type="Port" Display="always-hide" Required="false" Mask="false">3000</Config>
     <Config Name="Allow Guest Account Registration" Target="ACCOUNT_REGISTRATION" Default="false|true" Description="Allow guest account registration" Type="Variable" Display="always-hide" Required="true" Mask="false"/>
     <Config Name="JWT Secret" Target="JWT_SECRET" Default="" Description="Run `openssl rand -base64 32` to generate a secret" Type="Variable" Display="always-hide" Required="true" Mask="true"/>
     <Config Name="Allow HTTP" Target="HTTP_ALLOWED" Default="false|true" Description="Allow HTTP connections. Only set to true for local connections" Type="Variable" Display="always-hide" Required="true" Mask="false"/>

--- a/templates/deprecated/ntfy.xml
+++ b/templates/deprecated/ntfy.xml
@@ -20,7 +20,7 @@
     <Maintainer>
         <WebPage>https://github.com/nwithan8</WebPage>
     </Maintainer>
-    <Config Name="WebUI" Target="80" Default="6839" Mode="tcp" Description="Container Port: 80" Type="Port" Display="always" Required="true" Mask="false">6839</Config>
+    <Config Name="WebUI" Target="80" Default="6839" Mode="tcp" Description="Container Port: 80" Type="Port" Display="always" Required="false" Mask="false">6839</Config>
     <Config Name="Config Path" Target="/etc/ntfy" Default="" Mode="rw" Description="Where advanced configuration files are stored" Type="Path" Display="always" Required="false" Mask="false" />
     <Config Name="Cache Path" Target="/var/cache/ntfy" Default="" Mode="rw" Description="Use persistent message cache" Type="Path" Display="always" Required="false" Mask="false" />
 </Container>

--- a/templates/enclosed.xml
+++ b/templates/enclosed.xml
@@ -30,6 +30,6 @@
 
         Initial release
     </Changes>
-    <Config Name="Web UI Port" Target="8787" Default="8787" Mode="tcp" Description="Container Port: 8787" Type="Port" Display="always-hide" Required="true" Mask="false">8787</Config>
+    <Config Name="Web UI Port" Target="8787" Default="8787" Mode="tcp" Description="Container Port: 8787" Type="Port" Display="always-hide" Required="false" Mask="false">8787</Config>
     <Config Name="Config data" Target="/app/.data" Default="/mnt/user/appdata/enclosed/data" Mode="rw" Description="Config data for application" Type="Path" Display="advanced-hide" Required="true" Mask="false">/mnt/user/appdata/enclosed/data</Config>
 </Container>

--- a/templates/fass.xml
+++ b/templates/fass.xml
@@ -30,5 +30,5 @@
 
         Initial release
     </Changes>
-    <Config Name="API Port" Target="8000" Default="8000" Mode="tcp" Description="Container Port: 8000" Type="Port" Display="always" Required="true" Mask="false">8000</Config>
+    <Config Name="API Port" Target="8000" Default="8000" Mode="tcp" Description="Container Port: 8000" Type="Port" Display="always" Required="false" Mask="false">8000</Config>
 </Container>

--- a/templates/fladder.xml
+++ b/templates/fladder.xml
@@ -28,6 +28,6 @@
 
         Initial release
     </Changes>
-    <Config Name="Web UI Port" Target="80" Default="8080" Mode="tcp" Description="Container Port: 80" Type="Port" Display="always-hide" Required="true" Mask="false">8080</Config>
+    <Config Name="Web UI Port" Target="80" Default="8080" Mode="tcp" Description="Container Port: 80" Type="Port" Display="always-hide" Required="false" Mask="false">8080</Config>
     <Config Name="Lock to Base URL" Target="BASE_URL" Default="https://server-url" Description="Lock the front-end to a specific Jellyfin instance. Optional, remove to disable." Type="Variable" Display="always" Required="false" Mask="false">https://server-url</Config>
 </Container>

--- a/templates/free_games_claimer.xml
+++ b/templates/free_games_claimer.xml
@@ -29,7 +29,7 @@
 
         Initial release
     </Changes>
-    <Config Name="Web UI Port" Target="6080" Default="6080" Mode="tcp" Description="Container Port: 6080" Type="Port" Display="always" Required="true" Mask="false">6080</Config>
+    <Config Name="Web UI Port" Target="6080" Default="6080" Mode="tcp" Description="Container Port: 6080" Type="Port" Display="always" Required="false" Mask="false">6080</Config>
     <Config Name="Default login - Email" Target="EMAIL" Default="" Description="The email address to use for logging in" Type="Variable" Display="always" Required="true" Mask="false"/>
     <Config Name="Default login - Password" Target="PASSWORD" Default="" Description="The password to use for logging in" Type="Variable" Display="always" Required="true" Mask="true"/>
     <Config Name="Epic Games Store - Email" Target="EG_EMAIL" Default="" Description="The email address to use for logging in to the Epic Games Store. Overrides default email." Type="Variable" Display="always" Required="false" Mask="false"/>

--- a/templates/gollum.xml
+++ b/templates/gollum.xml
@@ -24,7 +24,7 @@
 
         Initial release
     </Changes>
-    <Config Name="Web UI Port" Target="4567" Default="4567" Mode="tcp" Description="Container Port: 4567" Type="Port" Display="always" Required="true" Mask="false">4567</Config>
+    <Config Name="Web UI Port" Target="4567" Default="4567" Mode="tcp" Description="Container Port: 4567" Type="Port" Display="always" Required="false" Mask="false">4567</Config>
     <Config Name="Data storage" Target="/wiki" Default="/mnt/user/appdata/gollum" Mode="rw" Description="Path to data storage" Type="Path" Display="advanced" Required="true" Mask="false">/mnt/user/appdata/gollum</Config>
     <Config Name="PUID" Target="PUID" Default="99" Description="" Type="Variable" Display="advanced" Required="true" Mask="false">99</Config>
     <Config Name="PGID" Target="PGID" Default="100" Description="" Type="Variable" Display="advanced" Required="true" Mask="false">100</Config>

--- a/templates/gpt4all.xml
+++ b/templates/gpt4all.xml
@@ -30,7 +30,7 @@
     <ExtraParams>--gpus all --shm-size 1g</ExtraParams>
     <PostArgs>--model-id $MODEL --num-shard $NUM_SHARD</PostArgs>
     <Config Name="HuggingFace Token" Target="HUGGING_FACE_HUB_TOKEN" Default="" Description="The HuggingFace token to use" Type="Variable" Display="always" Required="false" Mask="true"/>
-    <Config Name="API Port" Target="80" Default="8080" Mode="tcp" Description="Container Port: 8080" Type="Port" Display="always" Required="true" Mask="false">8080</Config>
+    <Config Name="API Port" Target="80" Default="8080" Mode="tcp" Description="Container Port: 8080" Type="Port" Display="always" Required="false" Mask="false">8080</Config>
     <Config Name="Data Path" Target="/data" Default="/mnt/user/appdata/gpt4all/data" Mode="rw" Description="Data directory" Type="Path" Display="advanced" Required="true" Mask="false">/mnt/user/appdata/gpt4all/data</Config>
     <Config Name="Use flash attention" Default="false|true" Target="USE_FLASH_ATTENTION" Type="Variable" Description="Use flash attention" Display="advanced" Required="false" Mask="false"/>
 </Container>

--- a/templates/gramps_web.xml
+++ b/templates/gramps_web.xml
@@ -31,7 +31,7 @@
 
         Initial release
     </Changes>
-    <Config Name="WebUI" Target="5000" Default="5000" Mode="tcp" Description="Container Port: 5000" Type="Port" Display="always" Required="true" Mask="false">5000</Config>
+    <Config Name="WebUI" Target="5000" Default="5000" Mode="tcp" Description="Container Port: 5000" Type="Port" Display="always" Required="false" Mask="false">5000</Config>
     <Config Name="Tree name" Target="GRAMPSWEB_TREE" Default="Gramps Web" Description="Name of the Gramps tree" Type="Variable" Display="always" Required="true" Mask="false"/>
     <Config Name="Users database path" Target="/app/users" Default="/mnt/user/appdata/gramps/users" Mode="rw" Description="Users database path" Type="Path" Display="advanced" Required="true" Mask="false">/mnt/user/appdata/gramps/users</Config>
     <Config Name="Search index path" Target="/app/indexdir" Default="/mnt/user/appdata/gramps/indexdir" Mode="rw" Description="Search index path" Type="Path" Display="advanced" Required="true" Mask="false">/mnt/user/appdata/gramps/indexdir</Config>

--- a/templates/haptic.xml
+++ b/templates/haptic.xml
@@ -26,5 +26,5 @@
 
         Initial release
     </Changes>
-    <Config Name="Web UI Port" Target="80" Default="3000" Mode="tcp" Description="Container Port: 3000" Type="Port" Display="always-hide" Required="true" Mask="false">3000</Config>
+    <Config Name="Web UI Port" Target="80" Default="3000" Mode="tcp" Description="Container Port: 3000" Type="Port" Display="always-hide" Required="false" Mask="false">3000</Config>
 </Container>

--- a/templates/hearchco_agent.xml
+++ b/templates/hearchco_agent.xml
@@ -31,7 +31,7 @@
         [br]
         This application requires a separate Redis database.
     </Requires>
-    <Config Name="Application Port" Target="8000" Default="8000" Mode="tcp" Description="Port over which the frontend will communicate with this backend" Type="Port" Display="always-hide" Required="true" Mask="false">8000</Config>
+    <Config Name="Application Port" Target="8000" Default="8000" Mode="tcp" Description="Port over which the frontend will communicate with this backend" Type="Port" Display="always-hide" Required="false" Mask="false">8000</Config>
     <Config Name="Frontend URLs" Target="HEARCHCO_SERVER_FRONTENDURLS" Default="http://localhost:3000" Description="Comma-separated list of frontend URLs that are allowed to communicate with this backend. Replace with IP:PORT or domain of your frontend" Type="Variable" Display="always-hide" Required="true" Mask="false">http://localhost:3000</Config>
     <Config Name="Redis Host" Target="HEARCHCO_SERVER_CACHE_REDIS_HOST" Default="" Description="Host of the Redis database" Type="Variable" Display="always-hide" Required="true" Mask="false"/>
     <Config Name="Redis Port" Target="HEARCHCO_SERVER_CACHE_REDIS_PORT" Default="6379" Description="Port of the Redis database" Type="Variable" Display="always-hide" Required="true" Mask="false">6379</Config>

--- a/templates/hearchco_frontend.xml
+++ b/templates/hearchco_frontend.xml
@@ -30,7 +30,7 @@
     <Requires>
         This is the frontend for the Hearchco metasearch engine. It requires an agent to also be running. &#xD;
     </Requires>
-    <Config Name="Web UI Port" Target="3000" Default="3000" Mode="tcp" Description="Container Port: 3000" Type="Port" Display="always-hide" Required="true" Mask="false">3000</Config>
+    <Config Name="Web UI Port" Target="3000" Default="3000" Mode="tcp" Description="Container Port: 3000" Type="Port" Display="always-hide" Required="false" Mask="false">3000</Config>
     <Config Name="Public URL" Target="PUBLIC_URI" Default="http://localhost:3000" Description="Publicly accessible URL for the frontend, used to advertise service. Replace with your domain." Type="Variable" Display="always-hide" Required="true" Mask="false">http://localhost:3000</Config>
     <Config Name="Agent URL" Target="API_URI" Default="http://localhost:8000" Description="URL for the agent, used to communicate with the backend. Replace with IP address or domain." Type="Variable" Display="always-hide" Required="true" Mask="false">http://localhost:8000</Config>
     <Config Name="Public Agent URL" Target="PUBLIC_API_URI" Default="http://localhost:8000" Description="Publicly accessible URL for the agent, used to fetch data from browser. Replace with your domain." Type="Variable" Display="always-hide" Required="true" Mask="false">http://localhost:8000</Config>

--- a/templates/hound.xml
+++ b/templates/hound.xml
@@ -29,6 +29,6 @@
     <Requires>
         Hound expects a `config.json` file to be present in the "Config Data" directory. This file should contain the configuration for Hound. See example: https://github.com/hound-search/hound/blob/main/config-example.json
     </Requires>
-    <Config Name="Web UI Port" Target="6080" Default="6080" Mode="tcp" Description="Container Port: 6080" Type="Port" Display="always-hide" Required="true" Mask="false">6080</Config>
+    <Config Name="Web UI Port" Target="6080" Default="6080" Mode="tcp" Description="Container Port: 6080" Type="Port" Display="always-hide" Required="false" Mask="false">6080</Config>
     <Config Name="Config Data" Target="/data" Default="/mnt/user/appdata/hound/data" Mode="rw" Description="Config data for application" Type="Path" Display="advanced-hide" Required="true" Mask="false">/mnt/user/appdata/hound/data</Config>
 </Container>

--- a/templates/hrconvert2.xml
+++ b/templates/hrconvert2.xml
@@ -27,5 +27,5 @@
 
         Initial release
     </Changes>
-    <Config Name="Web UI Port" Target="80" Default="8435" Mode="tcp" Description="Container Port: 80" Type="Port" Display="always-hide" Required="true" Mask="false">8435</Config>
+    <Config Name="Web UI Port" Target="80" Default="8435" Mode="tcp" Description="Container Port: 80" Type="Port" Display="always-hide" Required="false" Mask="false">8435</Config>
 </Container>

--- a/templates/hugo.xml
+++ b/templates/hugo.xml
@@ -31,6 +31,6 @@
         This container expects Hugo configuration files to be present in the "Site Content" path; otherwise, the container will not start. See documentation: https://gohugo.io/getting-started/configuration/
     </Requires>
     <PostArgs>server</PostArgs>
-    <Config Name="Web UI Port" Target="1313" Default="1313" Mode="tcp" Description="Container Port: 1313" Type="Port" Display="always-hide" Required="true" Mask="false">1313</Config>
+    <Config Name="Web UI Port" Target="1313" Default="1313" Mode="tcp" Description="Container Port: 1313" Type="Port" Display="always-hide" Required="false" Mask="false">1313</Config>
     <Config Name="Site Content" Target="/src" Default="/mnt/user/appdata/hugo/site" Mode="rw" Description="Site content to be served by Hugo" Type="Path" Display="always-hide" Required="true" Mask="false">/mnt/user/appdata/hugo/site</Config>
 </Container>

--- a/templates/huly_account.xml
+++ b/templates/huly_account.xml
@@ -31,7 +31,7 @@
         [br]
         This is the account management container for Huly. Other Huly containers are required to run the entire suite.
     </Requires>
-    <Config Name="App Port" Target="3000" Default="3000" Mode="tcp" Description="Allow other containers to access application" Type="Port" Display="always-hide" Required="true" Mask="false">3000</Config>
+    <Config Name="App Port" Target="3000" Default="3000" Mode="tcp" Description="Allow other containers to access application" Type="Port" Display="always-hide" Required="false" Mask="false">3000</Config>
     <Config Name="Secret Key" Target="SERVER_SECRET" Default="" Description="Needs to match across all Huly containers. Generate with `openssl rand -hex 32`" Type="Variable" Display="always-hide" Required="true" Mask="true"/>
     <Config Name="MongoDB Connection URL" Target="MONGO_URL" Default="mongodb://localhost:27017" Description="Connection URL for MongoDB." Type="Variable" Display="always-hide" Required="true" Mask="false">mongodb://localhost:27017</Config>
     <Config Name="Huly Transactor Connection URL" Target="TRANSACTOR_URL" Default="ws://localhost:3333" Description="Connection URL for Huly Transactor. Replace with server IP address and correct port." Type="Variable" Display="always-hide" Required="true" Mask="false">ws://localhost:3333</Config>

--- a/templates/huly_collaborator.xml
+++ b/templates/huly_collaborator.xml
@@ -31,7 +31,7 @@
         [br]
         This is the collaborator container for Huly. Other Huly containers are required to run the entire suite.
     </Requires>
-    <Config Name="App Port" Target="3078" Default="3078" Mode="tcp" Description="Allow other containers to access application" Type="Port" Display="always-hide" Required="true" Mask="false">3078</Config>
+    <Config Name="App Port" Target="3078" Default="3078" Mode="tcp" Description="Allow other containers to access application" Type="Port" Display="always-hide" Required="false" Mask="false">3078</Config>
     <Config Name="Secret Key" Target="SECRET" Default="" Description="Needs to match across all Huly containers. Generate with `openssl rand -hex 32`" Type="Variable" Display="always-hide" Required="true" Mask="true"/>
     <Config Name="Accounts URL" Target="ACCOUNTS_URL" Default="http://localhost:3000" Description="URL for the accounts service (this container). Replace with server IP address and correct port." Type="Variable" Display="always-hide" Required="true" Mask="false">http://localhost:3000</Config>
     <Config Name="MongoDB Connection URL" Target="MONGO_URL" Default="mongodb://localhost:27017" Description="Connection URL for MongoDB." Type="Variable" Display="always-hide" Required="true" Mask="false">mongodb://localhost:27017</Config>

--- a/templates/huly_frontend.xml
+++ b/templates/huly_frontend.xml
@@ -32,7 +32,7 @@
         [br]
         This is the frontend container for Huly. Other Huly containers are required to run the entire suite.
     </Requires>
-    <Config Name="App Port" Target="8080" Default="8080" Mode="tcp" Description="Access web interface" Type="Port" Display="always-hide" Required="true" Mask="false">8080</Config>
+    <Config Name="App Port" Target="8080" Default="8080" Mode="tcp" Description="Access web interface" Type="Port" Display="always-hide" Required="false" Mask="false">8080</Config>
     <Config Name="Secret Key" Target="SERVER_SECRET" Default="" Description="Needs to match across all Huly containers. Generate with `openssl rand -hex 32`" Type="Variable" Display="always-hide" Required="true" Mask="true"/>
     <Config Name="Accounts URL" Target="ACCOUNTS_URL" Default="http://localhost:3000" Description="URL for the accounts service (this container). Replace with server IP address and correct port." Type="Variable" Display="always-hide" Required="true" Mask="false">http://localhost:3000</Config>
     <Config Name="Rekoni URL" Target="REKONI_URL" Default="http://localhost:4004" Description="URL for the Rekoni service. Replace with server IP address and correct port." Type="Variable" Display="always-hide" Required="true" Mask="false">http://localhost:4004</Config>

--- a/templates/huly_rekoni.xml
+++ b/templates/huly_rekoni.xml
@@ -31,6 +31,6 @@
         [br]
         This is the Rekoni container for Huly. Other Huly containers are required to run the entire suite.
     </Requires>
-    <Config Name="App Port" Target="4004" Default="4004" Mode="tcp" Description="Allow other containers to access application" Type="Port" Display="always-hide" Required="true" Mask="false">4004</Config>
+    <Config Name="App Port" Target="4004" Default="4004" Mode="tcp" Description="Allow other containers to access application" Type="Port" Display="always-hide" Required="false" Mask="false">4004</Config>
     <Config Name="Secret Key" Target="SECRET" Default="" Description="Needs to match across all Huly containers. Generate with `openssl rand -hex 32`" Type="Variable" Display="always-hide" Required="true" Mask="true"/>
 </Container>

--- a/templates/huly_transactor.xml
+++ b/templates/huly_transactor.xml
@@ -31,7 +31,7 @@
         [br]
         This is the transactor container for Huly. Other Huly containers are required to run the entire suite.
     </Requires>
-    <Config Name="App Port" Target="3333" Default="3333" Mode="tcp" Description="Allow other containers to access application" Type="Port" Display="always-hide" Required="true" Mask="false">3333</Config>
+    <Config Name="App Port" Target="3333" Default="3333" Mode="tcp" Description="Allow other containers to access application" Type="Port" Display="always-hide" Required="false" Mask="false">3333</Config>
     <Config Name="Secret Key" Target="SERVER_SECRET" Default="" Description="Needs to match across all Huly containers. Generate with `openssl rand -hex 32`" Type="Variable" Display="always-hide" Required="true" Mask="true"/>
     <Config Name="Server Cursor Max Items" Target="SERVER_CURSOR_MAXITEMS" Default="30000" Description="" Type="Variable" Display="always-hide" Required="true" Mask="false">30000</Config>
     <Config Name="ElasticSearch URL" Target="ELASTIC_URL" Default="http://localhost:9200" Description="URL for the ElasticSearch service. Replace with server IP address and correct port." Type="Variable" Display="always-hide" Required="true" Mask="false">http://localhost:9200</Config>

--- a/templates/imgproxy.xml
+++ b/templates/imgproxy.xml
@@ -24,5 +24,5 @@
 
         Initial release
     </Changes>
-    <Config Name="WebUI" Target="8080" Default="8080" Mode="tcp" Description="Container Port: 8080" Type="Port" Display="always" Required="true" Mask="false">8080</Config>
+    <Config Name="WebUI" Target="8080" Default="8080" Mode="tcp" Description="Container Port: 8080" Type="Port" Display="always" Required="false" Mask="false">8080</Config>
 </Container>

--- a/templates/immich_kiosk.xml
+++ b/templates/immich_kiosk.xml
@@ -31,7 +31,7 @@
     <Requires>
         Requires a separate Immich server. Container requires a "config.yaml" file at the "Config File" path BEFORE starting if using config file; otherwise use environmental variables. See the project page for more information: https://github.com/damongolding/immich-kiosk?tab=readme-ov-file#configuration
     </Requires>
-    <Config Name="Web UI Port" Target="3000" Default="3000" Mode="tcp" Description="Container Port: 3000" Type="Port" Display="always" Required="true" Mask="false">3000</Config>
+    <Config Name="Web UI Port" Target="3000" Default="3000" Mode="tcp" Description="Container Port: 3000" Type="Port" Display="always" Required="false" Mask="false">3000</Config>
     <Config Name="Config File" Target="/config.yaml" Default="/mnt/user/appdata/immich_kiosk/config.yaml" Mode="rw" Description="Config file for application. Remove this if using environmental variables instead." Type="Path" Display="always" Required="false" Mask="false">/mnt/user/appdata/immich_kiosk/config.yaml</Config>
     <Config Name="Immich URL" Target="KIOSK_IMMICH_URL" Default="" Description="The URL to the Immich Server" Type="Variable" Display="always" Required="false" Mask="false"/>
     <Config Name="Immich API Key" Target="KIOSK_IMMICH_API_KEY" Default="" Description="The API for your Immich server" Type="Variable" Display="always" Required="false" Mask="true"/>

--- a/templates/immich_power_tools.xml
+++ b/templates/immich_power_tools.xml
@@ -27,7 +27,7 @@
     <Requires>
         Requires a separate Immich server and Postgres database.
     </Requires>
-    <Config Name="Web UI Port" Target="3000" Default="3000" Mode="tcp" Description="Container Port: 3000" Type="Port" Display="always" Required="true" Mask="false">3000</Config>
+    <Config Name="Web UI Port" Target="3000" Default="3000" Mode="tcp" Description="Container Port: 3000" Type="Port" Display="always" Required="false" Mask="false">3000</Config>
     <Config Name="Immich URL" Target="IMMICH_URL" Default="" Description="The URL to the Immich Server" Type="Variable" Display="always" Required="false" Mask="false"/>
     <Config Name="Immich API Key" Target="IMMICH_API_KEY" Default="" Description="The API for your Immich server" Type="Variable" Display="always" Required="false" Mask="true"/>
     <Config Name="Database Host" Target="DB_HOST" Default="localhost" Description="The host for the Postgres database connection" Type="Variable" Display="always" Required="false" Mask="false">localhost</Config>

--- a/templates/invoke_ai.xml
+++ b/templates/invoke_ai.xml
@@ -38,7 +38,7 @@
         Initial release
     </Changes>
     <ExtraParams>--gpus=all</ExtraParams>
-    <Config Name="WebUI" Target="9090" Default="9090" Mode="tcp" Description="Container Port: 9090" Type="Port" Display="always" Required="true" Mask="false">9090</Config>
+    <Config Name="WebUI" Target="9090" Default="9090" Mode="tcp" Description="Container Port: 9090" Type="Port" Display="always" Required="false" Mask="false">9090</Config>
     <Config Name="HuggingFace Hub Token" Target="HUGGING_FACE_HUB_TOKEN" Default="" Description="HuggingFace Hub token for downloading models from private repositories" Type="Variable" Display="always" Required="false" Mask="false"/>
     <Config Name="Appdata and Model Storage Path" Target="/invokeai_root" Default="/mnt/user/appdata/invoke_ai" Mode="rw" Description="Path for app data and models storage" Type="Path" Display="advanced" Required="true" Mask="false">/mnt/user/appdata/invoke_ai</Config>
     <Config Name="Data root" Target="INVOKEAI_ROOT" Default="/invokeai_root" Description="Location of InvokeAI root directory inside the container" Type="Variable" Display="advanced-hide" Required="true" Mask="false">/invokeai_root</Config>

--- a/templates/iptv_proxy.xml
+++ b/templates/iptv_proxy.xml
@@ -29,7 +29,7 @@
 
         Initial release
     </Changes>
-    <Config Name="Stream Port" Target="8080" Default="8080" Mode="tcp" Description="Container Port: 8080" Type="Port" Display="always" Required="true" Mask="false">8080</Config>
+    <Config Name="Stream Port" Target="8080" Default="8080" Mode="tcp" Description="Container Port: 8080" Type="Port" Display="always" Required="false" Mask="false">8080</Config>
     <Config Name="M3U Storage Path" Target="/root/iptv" Default="/mnt/user/appdata/iptv-proxy/m3u" Mode="rw" Description="Path to M3U files" Type="Path" Display="advanced" Required="true" Mask="false">/mnt/user/appdata/iptv-proxy/m3u</Config>
     <Config Name="M3U URL" Target="M3U_URL" Default="/root/iptv/iptv.m3u" Description="Path to M3U file (local in M3U Storage Path or remote URL). Remove if using XtreamCodes." Type="Variable" Display="always" Required="false" Mask="false">/root/iptv/iptv.m3u</Config>
     <Config Name="XtreamCodes Username" Target="XTREAM_USER" Default="" Description="Username for XtreamCodes. Remove if using M3U." Type="Variable" Display="always" Required="false" Mask="false" />

--- a/templates/librex.xml
+++ b/templates/librex.xml
@@ -27,7 +27,7 @@
 
         Initial release
     </Changes>
-    <Config Name="Web UI Port" Target="8080" Default="8080" Mode="tcp" Description="Container Port: 8080" Type="Port" Display="always-hide" Required="true" Mask="false">8080</Config>
+    <Config Name="Web UI Port" Target="8080" Default="8080" Mode="tcp" Description="Container Port: 8080" Type="Port" Display="always-hide" Required="false" Mask="false">8080</Config>
     <Config Name="Google - Domain" Target="CONFIG_GOOGLE_DOMAIN" Default="com" Description="Which Google domain the search will be done on. Change according to your country." Type="Variable" Display="always-hide" Required="true" Mask="false">com</Config>
     <Config Name="Google - Site Language" Target="CONFIG_GOOGLE_LANGUAGE_SITE" Default="en" Description="Language to use for Google site" Type="Variable" Display="always-hide" Required="true" Mask="false">en</Config>
     <Config Name="Google - Results Language" Target="CONFIG_GOOGLE_LANGUAGE_RESULTS" Default="en" Description="Language to use for Google results" Type="Variable" Display="always-hide" Required="true" Mask="false">en</Config>

--- a/templates/librey.xml
+++ b/templates/librey.xml
@@ -32,7 +32,7 @@
     <Requires>
         Please see the documentation for all available settings: https://github.com/Ahwxorg/LibreY/tree/main/docker#environment-variables-that-can-be-set-in-the-docker-container
     </Requires>
-    <Config Name="Web UI Port" Target="8080" Default="8080" Mode="tcp" Description="Container Port: 8080" Type="Port" Display="always-hide" Required="true" Mask="false">8080</Config>
+    <Config Name="Web UI Port" Target="8080" Default="8080" Mode="tcp" Description="Container Port: 8080" Type="Port" Display="always-hide" Required="false" Mask="false">8080</Config>
     <Config Name="Language" Target="CONFIG_LANGUAGE" Default="en" Description="Language to perform searches in" Type="Variable" Display="always-hide" Required="true" Mask="false">en</Config>
     <Config Name="Text Search Engine" Target="CONFIG_TEXT_SEARCH_ENGINE" Default="auto|brave|duckduckgo|ecosia|google|mojeek|yandex" Description="Text search engine to use. Set 'auto' to use any available search engine." Type="Variable" Display="advanced-hide" Required="true" Mask="false"/>
     <Config Name="Default Number of Results" Target="CONFIG_NUMBER_OF_RESULTS" Default="10" Description="Number of results to show by default" Type="Variable" Display="always-hide" Required="true" Mask="false">10</Config>

--- a/templates/livekit.xml
+++ b/templates/livekit.xml
@@ -35,8 +35,8 @@
         Initial release
     </Changes>
     <PostArgs>--config /config/config.yaml</PostArgs>
-    <Config Name="Main Port" Target="7880" Default="7880" Mode="tcp" Description="Container Port: 7880" Type="Port" Display="always" Required="true" Mask="false">7880</Config>
+    <Config Name="Main Port" Target="7880" Default="7880" Mode="tcp" Description="Container Port: 7880" Type="Port" Display="always" Required="false" Mask="false">7880</Config>
     <Config Name="WebRTC UDP Ports" Target="50000-60000" Default="50000-60000" Mode="udp" Description="UDP ports for client traffic" Type="Port" Display="advanced" Required="true" Mask="false">50000-60000</Config>
-    <Config Name="WebRTC TCP Port" Target="7881" Default="7881" Mode="tcp" Description="TCP port for client traffic when UDP not available" Type="Port" Display="advanced" Required="true" Mask="false">7881</Config>
+    <Config Name="WebRTC TCP Port" Target="7881" Default="7881" Mode="tcp" Description="TCP port for client traffic when UDP not available" Type="Port" Display="advanced" Required="false" Mask="false">7881</Config>
     <Config Name="Config Path" Target="/config" Default="/mnt/user/appdata/livekit" Mode="rw" Description="Parent folder for config.yaml file" Type="Path" Display="advanced" Required="true" Mask="false">/mnt/user/appdata/livekit</Config>
 </Container>

--- a/templates/llama_cpp.xml
+++ b/templates/llama_cpp.xml
@@ -42,6 +42,6 @@
 
         Initial release
     </Changes>
-    <Config Name="WebUI" Target="8000" Default="8000" Mode="tcp" Description="Container Port: 8000" Type="Port" Display="always" Required="true" Mask="false">8000</Config>
+    <Config Name="WebUI" Target="8000" Default="8000" Mode="tcp" Description="Container Port: 8000" Type="Port" Display="always" Required="false" Mask="false">8000</Config>
     <Config Name="Model Storage Path" Target="/models" Default="/mnt/user/appdata/llama_cpp/model" Mode="rw" Description="Storage for model" Type="Path" Display="advanced" Required="true" Mask="false">/mnt/user/appdata/llama_cpp/model</Config>
 </Container>

--- a/templates/local_ai.xml
+++ b/templates/local_ai.xml
@@ -104,7 +104,7 @@
         Initial release
     </Changes>
     <ExtraParams>--gpus=all</ExtraParams>
-    <Config Name="WebUI" Target="8080" Default="8080" Mode="tcp" Description="Container Port: 8080" Type="Port" Display="always" Required="true" Mask="false">8080</Config>
+    <Config Name="WebUI" Target="8080" Default="8080" Mode="tcp" Description="Container Port: 8080" Type="Port" Display="always" Required="false" Mask="false">8080</Config>
     <Config Name="Debug mode" Target="DEBUG" Default="true|false" Description="Whether to enable debug mode" Type="Variable" Display="advanced" Required="true" Mask="false"/>
     <Config Name="Model Storage Path" Target="/build/models" Default="/mnt/user/appdata/local_ai/models" Mode="rw" Description="Storage for models" Type="Path" Display="advanced" Required="true" Mask="false">/mnt/user/appdata/local_ai/models</Config>
 </Container>

--- a/templates/localtunnel.xml
+++ b/templates/localtunnel.xml
@@ -28,5 +28,5 @@
         Initial release
     </Changes>
     <PostArgs>--port 3000</PostArgs>
-    <Config Name="Traffic Port" Target="3000" Default="3000" Mode="tcp" Description="Container Port: 3000" Type="Port" Display="always-hide" Required="true" Mask="false">3000</Config>
+    <Config Name="Traffic Port" Target="3000" Default="3000" Mode="tcp" Description="Container Port: 3000" Type="Port" Display="always-hide" Required="false" Mask="false">3000</Config>
 </Container>

--- a/templates/maybe.xml
+++ b/templates/maybe.xml
@@ -33,7 +33,7 @@
     <Requires>
         Requires a separate Postgres database. See the Maybe documentation for more information: https://github.com/maybe-finance/maybe/blob/main/docs/hosting/docker.md
     </Requires>
-    <Config Name="Web UI Port" Target="3000" Default="3000" Mode="tcp" Description="Container Port: 3000" Type="Port" Display="always-hide" Required="true" Mask="false">3000</Config>
+    <Config Name="Web UI Port" Target="3000" Default="3000" Mode="tcp" Description="Container Port: 3000" Type="Port" Display="always-hide" Required="false" Mask="false">3000</Config>
     <Config Name="Secret Key" Target="SECRET_KEY_BASE" Default="" Description="Secret key. Run `openssl rand -hex 64` to generate a secret" Type="Variable" Display="always-hide" Required="true" Mask="true"/>
     <Config Name="Postgres - Host" Target="DB_HOST" Default="" Description="Postgres database host" Type="Variable" Display="always-hide" Required="true" Mask="false"/>
     <Config Name="Postgres - Port" Target="DB_PORT" Default="5432" Description="Postgres database port" Type="Variable" Display="always-hide" Required="true" Mask="false">5432</Config>

--- a/templates/mdblistarr.xml
+++ b/templates/mdblistarr.xml
@@ -29,6 +29,6 @@
 
         Initial release
     </Changes>
-    <Config Name="WebUI" Target="5353" Default="" Mode="tcp" Description="Container Port: 5353" Type="Port" Display="always" Required="true" Mask="false">5353</Config>
+    <Config Name="WebUI" Target="5353" Default="" Mode="tcp" Description="Container Port: 5353" Type="Port" Display="always" Required="false" Mask="false">5353</Config>
     <Config Name="Database Path" Target="/usr/src/db" Default="/mnt/user/appdata/mdblistarr/db" Mode="rw" Description="Storage for database" Type="Path" Display="advanced" Required="true" Mask="false">/mnt/user/appdata/mdblistarr/db</Config>
 </Container>

--- a/templates/mixwave_api.xml
+++ b/templates/mixwave_api.xml
@@ -31,7 +31,7 @@
         [br]
         This container requires a separate Redis database.
     </Requires>
-    <Config Name="Application Port" Target="52001" Default="52001" Mode="tcp" Description="Port over which other containers will communicate with this container" Type="Port" Display="always-hide" Required="true" Mask="false">52001</Config>
+    <Config Name="Application Port" Target="52001" Default="52001" Mode="tcp" Description="Port over which other containers will communicate with this container" Type="Port" Display="always-hide" Required="false" Mask="false">52001</Config>
     <Config Name="Redis - Host" Target="REDIS_HOST" Default="" Description="Hostname of the Redis database" Type="Variable" Display="always-hide" Required="true" Mask="false"/>
     <Config Name="Redis - Port" Target="REDIS_PORT" Default="6379" Description="Port of the Redis database" Type="Variable" Display="always-hide" Required="true" Mask="false">6379</Config>
     <Config Name="Public API Endpoint" Target="PUBLIC_API_ENDPOINT" Default="http://localhost:520001" Description="Publicly accessible URL for Mixin API container. Replace with your IP or domain." Type="Variable" Display="always-hide" Required="true" Mask="false">http://localhost:52001</Config>

--- a/templates/mixwave_dashboard.xml
+++ b/templates/mixwave_dashboard.xml
@@ -30,7 +30,7 @@
     <Requires>
         This is the frontend for the Mixin suite. It requires other Mixin containers to be running. &#xD;
     </Requires>
-    <Config Name="Web UI Port" Target="52000" Default="52000" Mode="tcp" Description="Container Port: 52000" Type="Port" Display="always-hide" Required="true" Mask="false">52000</Config>
+    <Config Name="Web UI Port" Target="52000" Default="52000" Mode="tcp" Description="Container Port: 52000" Type="Port" Display="always-hide" Required="false" Mask="false">52000</Config>
     <Config Name="Public API Endpoint" Target="PUBLIC_API_ENDPOINT" Default="http://localhost:520001" Description="Publicly accessible URL for Mixin API container. Replace with your IP or domain." Type="Variable" Display="always-hide" Required="true" Mask="false">http://localhost:52001</Config>
     <Config Name="Public Stitcher Endpoint" Target="PUBLIC_STITCHER_ENDPOINT" Default="http://localhost:52002" Description="Publicly accessible URL for Mixin Stitcher container. Replace with your IP or domain." Type="Variable" Display="always-hide" Required="true" Mask="false">http://localhost:52002</Config>
 </Container>

--- a/templates/mixwave_stitcher.xml
+++ b/templates/mixwave_stitcher.xml
@@ -31,7 +31,7 @@
         [br]
         This container requires a separate Redis database.
     </Requires>
-    <Config Name="Application Port" Target="52002" Default="52002" Mode="tcp" Description="Port over which other containers will communicate with this container" Type="Port" Display="always-hide" Required="true" Mask="false">52002</Config>
+    <Config Name="Application Port" Target="52002" Default="52002" Mode="tcp" Description="Port over which other containers will communicate with this container" Type="Port" Display="always-hide" Required="false" Mask="false">52002</Config>
     <Config Name="Redis - Host" Target="REDIS_HOST" Default="" Description="Hostname of the Redis database" Type="Variable" Display="always-hide" Required="true" Mask="false"/>
     <Config Name="Redis - Port" Target="REDIS_PORT" Default="6379" Description="Port of the Redis database" Type="Variable" Display="always-hide" Required="true" Mask="false">6379</Config>
     <Config Name="Public API Endpoint" Target="PUBLIC_API_ENDPOINT" Default="http://localhost:520001" Description="Publicly accessible URL for Mixin API container. Replace with your IP or domain." Type="Variable" Display="always-hide" Required="true" Mask="false">http://localhost:52001</Config>

--- a/templates/morphos.xml
+++ b/templates/morphos.xml
@@ -26,6 +26,6 @@
 
         Initial release
     </Changes>
-    <Config Name="WebUI" Target="8080" Default="8080" Mode="tcp" Description="Container Port: 8080" Type="Port" Display="always" Required="true" Mask="false">8080</Config>
+    <Config Name="WebUI" Target="8080" Default="8080" Mode="tcp" Description="Container Port: 8080" Type="Port" Display="always" Required="false" Mask="false">8080</Config>
     <Config Name="Temporary data" Target="/tmp" Default="/tmp" Mode="rw" Description="Path to temporary data" Type="Path" Display="advanced-hide" Required="true" Mask="false">/tmp</Config>
 </Container>

--- a/templates/nitter.xml
+++ b/templates/nitter.xml
@@ -33,6 +33,6 @@
         Initial release
     </Changes>
     <ExtraParams>--cap-drop ALL</ExtraParams>
-    <Config Name="Web UI Port" Target="8080" Default="8080" Mode="tcp" Description="Container Port: 8080" Type="Port" Display="always-hide" Required="true" Mask="false">8080</Config>
+    <Config Name="Web UI Port" Target="8080" Default="8080" Mode="tcp" Description="Container Port: 8080" Type="Port" Display="always-hide" Required="false" Mask="false">8080</Config>
     <Config Name="Nitter Configuration" Target="/src/nitter.conf" Default="" Description="Path to Nitter configuration file" Mode="ro" Type="Path" Display="always-hide" Required="true" Mask="false"/>
 </Container>

--- a/templates/opodsync.xml
+++ b/templates/opodsync.xml
@@ -30,6 +30,6 @@
     <Requires>
         Expects a `config.local.php` file in the "Config Data" path. See documentation: https://github.com/kd2org/opodsync?tab=readme-ov-file#configuration
     </Requires>
-    <Config Name="Web UI Port" Target="8080" Default="8080" Mode="tcp" Description="Container Port: 8080" Type="Port" Display="always-hide" Required="true" Mask="false">8080</Config>
+    <Config Name="Web UI Port" Target="8080" Default="8080" Mode="tcp" Description="Container Port: 8080" Type="Port" Display="always-hide" Required="false" Mask="false">8080</Config>
     <Config Name="Config Data" Target="/var/www/server/data" Default="/mnt/user/appdata/opodsync/config" Mode="rw" Description="Path to config data" Type="Path" Display="advanced-hide" Required="true" Mask="false">/mnt/user/appdata/opodsync/config</Config>
 </Container>

--- a/templates/otterwiki.xml
+++ b/templates/otterwiki.xml
@@ -28,7 +28,7 @@
 
         Initial release
     </Changes>
-    <Config Name="Web UI Port" Target="80" Default="80" Mode="tcp" Description="Container Port: 80" Type="Port" Display="always" Required="true" Mask="false">80</Config>
+    <Config Name="Web UI Port" Target="80" Default="80" Mode="tcp" Description="Container Port: 80" Type="Port" Display="always" Required="false" Mask="false">80</Config>
     <Config Name="Data storage" Target="/app-data" Default="/mnt/user/appdata/otterwiki" Mode="rw" Description="Path to data storage" Type="Path" Display="advanced" Required="true" Mask="false">/mnt/user/appdata/otterwiki</Config>
     <Config Name="PUID" Target="PUID" Default="99" Description="" Type="Variable" Display="advanced" Required="true" Mask="false">99</Config>
     <Config Name="PGID" Target="PGID" Default="100" Description="" Type="Variable" Display="advanced" Required="true" Mask="false">100</Config>

--- a/templates/peanut.xml
+++ b/templates/peanut.xml
@@ -27,7 +27,7 @@
 
         Initial release
     </Changes>
-    <Config Name="Web UI" Target="8080" Default="8080" Mode="tcp" Description="Container Port: 8080" Type="Port" Display="always" Required="true" Mask="false">8080</Config>
+    <Config Name="Web UI" Target="8080" Default="8080" Mode="tcp" Description="Container Port: 8080" Type="Port" Display="always" Required="false" Mask="false">8080</Config>
     <Config Name="NUT Server Host" Target="NUT_HOST" Default="" Description="Hostname or IP of the NUT server" Type="Variable" Display="always" Required="true" Mask="false"/>
     <Config Name="NUT Server Port" Target="NUT_PORT" Default="3493" Description="Port of the NUT server" Type="Variable" Display="always" Required="true" Mask="false"/>
     <Config Name="NUT Username" Target="USERNAME" Default="" Description="Username for the NUT server" Type="Variable" Display="advanced" Required="false" Mask="false"/>

--- a/templates/pinepods.xml
+++ b/templates/pinepods.xml
@@ -30,7 +30,7 @@
     <Requires>
         This template requires a separate MariaDB or PostgreSQL database.
     </Requires>
-    <Config Name="Web UI Port" Target="8040" Default="8040" Mode="tcp" Description="Container Port: 8040" Type="Port" Display="always-hide" Required="true" Mask="false">8040</Config>
+    <Config Name="Web UI Port" Target="8040" Default="8040" Mode="tcp" Description="Container Port: 8040" Type="Port" Display="always-hide" Required="false" Mask="false">8040</Config>
     <Config Name="Username" Target="USERNAME" Default="" Description="Username for login" Type="Variable" Display="always-hide" Required="true" Mask="false"/>
     <Config Name="Password" Target="PASSWORD" Default="" Description="Password for login" Type="Variable" Display="always-hide" Required="true" Mask="true"/>
     <Config Name="User Full Name" Target="FULLNAME" Default="" Description="Full name of user" Type="Variable" Display="always-hide" Required="true" Mask="false"/>

--- a/templates/plex_rewind.xml
+++ b/templates/plex_rewind.xml
@@ -35,7 +35,7 @@
 
         Initial release
     </Changes>
-    <Config Name="WebUI" Target="8383" Default="8383" Mode="tcp" Description="Container Port: 8383" Type="Port" Display="always" Required="true" Mask="false">8383</Config>
+    <Config Name="WebUI" Target="8383" Default="8383" Mode="tcp" Description="Container Port: 8383" Type="Port" Display="always" Required="false" Mask="false">8383</Config>
     <Config Name="Site URL" Target="NEXT_PUBLIC_SITE_URL" Default="http://192.168.1.1:8383" Description="IMPORTANT: Change to your server IP address and port, or domain if app is publicly exposed." Type="Variable" Display="always" Required="true" Mask="false" />
     <Config Name="Authentication Secret" Target="NEXTAUTH_SECRET" Default="" Description="Required to encrypt authentication JWT token. Run `openssl rand -base64 32` to generate." Type="Variable" Display="always" Required="true" Mask="true" />
     <Config Name="Authentication URL" Target="NEXTAUTH_URL" Default="http://192.168.1.1:8383" Description="IMPORTANT: Change to your server IP address and port, or domain if app is publicly exposed." Type="Variable" Display="always" Required="true" Mask="false" />

--- a/templates/pocket_id.xml
+++ b/templates/pocket_id.xml
@@ -34,13 +34,13 @@
 
         Initial release
     </Changes>
-    <Config Name="WebUI" Target="80" Default="3000" Mode="tcp" Description="Port to access WebUI" Type="Port" Display="always-hide" Required="true" Mask="false">3000</Config>
+    <Config Name="WebUI" Target="80" Default="3000" Mode="tcp" Description="Port to access WebUI" Type="Port" Display="always-hide" Required="false" Mask="false">3000</Config>
     <Config Name="Public App URL" Target="PUBLIC_APP_URL" Default="http://localhost" Description="The URL where you will access the app. Recommended to change from default." Type="Variable" Display="always-hide" Required="true" Mask="false">http://localhost</Config>
     <Config Name="Data Path" Target="/app/backend/data" Default="/mnt/user/appdata/pocket-id/data" Mode="rw" Description="Data directory" Type="Path" Display="advanced-hide" Required="true" Mask="false">/mnt/user/appdata/pocket-id/data</Config>
     <Config Name="Database Path" Target="DB_PATH" Default="data/pocket-id.db" Description="Path inside the container to the SQLite database file" Type="Variable" Display="advanced-hide" Required="true" Mask="false">data/pocket-id.db</Config>
     <Config Name="Upload Path" Target="UPLOAD_PATH" Default="data/uploads" Description="Path inside the container where uploaded files are stored" Type="Variable" Display="advanced-hide" Required="true" Mask="false">data/uploads</Config>
-    <Config Name="Frontend Port" Target="PORT" Default="3000" Mode="tcp" Description="The port inside the container on which the frontend should listen" Type="Variable" Display="advanced-hide" Required="true" Mask="false">3000</Config>
-    <Config Name="Backend Port" Target="BACKEND_PORT" Default="8080" Mode="tcp" Description="The port inside the container on which the backend should listen" Type="Variable" Display="advanced-hide" Required="true" Mask="false">8080</Config>
+    <Config Name="Frontend Port" Target="PORT" Default="3000" Mode="tcp" Description="The port inside the container on which the frontend should listen" Type="Variable" Display="advanced-hide" Required="false" Mask="false">3000</Config>
+    <Config Name="Backend Port" Target="BACKEND_PORT" Default="8080" Mode="tcp" Description="The port inside the container on which the backend should listen" Type="Variable" Display="advanced-hide" Required="false" Mask="false">8080</Config>
     <Config Name="PUID" Target="PUID" Default="099" Description="" Type="Variable" Display="advanced" Required="true" Mask="false">099</Config>
     <Config Name="PGID" Target="PGID" Default="100" Description="" Type="Variable" Display="advanced" Required="true" Mask="false">100</Config>
 </Container>

--- a/templates/postiz.xml
+++ b/templates/postiz.xml
@@ -27,8 +27,8 @@
     <Requires>
         Requires separate Postgres and Redis databases. See documentation for more information: https://docs.postiz.com/installation/docker-compose#example-docker-composeyml-file
     </Requires>
-    <Config Name="Web UI Port" Target="4200" Default="4200" Mode="tcp" Description="Container Port: 4200" Type="Port" Display="always" Required="true" Mask="false">4200</Config>
-    <Config Name="Backend Port" Target="3000" Default="3000" Mode="tcp" Description="Container Port: 3000" Type="Port" Display="always" Required="true" Mask="false">3000</Config>
+    <Config Name="Web UI Port" Target="4200" Default="4200" Mode="tcp" Description="Container Port: 4200" Type="Port" Display="always" Required="false" Mask="false">4200</Config>
+    <Config Name="Backend Port" Target="3000" Default="3000" Mode="tcp" Description="Container Port: 3000" Type="Port" Display="always" Required="false" Mask="false">3000</Config>
     <Config Name="Web UI URL" Target="MAIN_URL" Default="https://SERVER_IP_ADDRESS:4200" Description="The public URL to the Postiz Web UI. Provide server IP address." Type="Variable" Display="always" Required="true" Mask="false">https://SERVER_IP_ADDRESS:4200</Config>
     <Config Name="Public Frontend URL" Target="FRONTEND_URL" Default="https://SERVER_IP_ADDRESS:4200" Description="The public URL to the Postiz frontend. Same as Web UI URL." Type="Variable" Display="always" Required="true" Mask="false">https://SERVER_IP_ADDRESS:4200</Config>
     <Config Name="Public Backend URL" Target="NEXT_PUBLIC_BACKEND_URL" Default="https://SERVER_IP_ADDRESS:3000" Description="The public URL to the Postiz backend. Provide server IP address." Type="Variable" Display="always" Required="true" Mask="false">https://SERVER_IP_ADDRESS:3000</Config>

--- a/templates/radicle.xml
+++ b/templates/radicle.xml
@@ -35,7 +35,7 @@
 
         Initial release
     </Changes>
-    <Config Name="Web UI Port" Target="5232" Default="5232" Mode="tcp" Description="Container Port: 5232" Type="Port" Display="always" Required="true" Mask="false">5232</Config>
+    <Config Name="Web UI Port" Target="5232" Default="5232" Mode="tcp" Description="Container Port: 5232" Type="Port" Display="always" Required="false" Mask="false">5232</Config>
     <Config Name="Config path" Target="/config" Default="/mnt/user/appdata/radicale/config" Mode="ro" Description="Parent folder storing config file" Type="Path" Display="advanced" Required="true" Mask="false">/mnt/user/appdata/radicale/config</Config>
     <Config Name="Data path" Target="/data" Default="/mnt/user/appdata/radicale/data" Mode="rw" Description="Data path" Type="Path" Display="advanced" Required="true" Mask="false">/mnt/user/appdata/radicale/data</Config>
 

--- a/templates/retrom.xml
+++ b/templates/retrom.xml
@@ -31,8 +31,8 @@
         [br]
         This application requires a separate Postgres database. Configuration data for the Postgres container (host, username, password, database name) should be updated in the `config.json` file.
     </Requires>
-    <Config Name="Web UI Port" Target="3000" Default="3000" Mode="tcp" Description="Access web interface" Type="Port" Display="always-hide" Required="true" Mask="false">3000</Config>
-    <Config Name="Service Port" Target="5101" Default="5101" Mode="tcp" Description="Allow external clients to connect to server" Type="Port" Display="always-hide" Required="true" Mask="false">5101</Config>
+    <Config Name="Web UI Port" Target="3000" Default="3000" Mode="tcp" Description="Access web interface" Type="Port" Display="always-hide" Required="false" Mask="false">3000</Config>
+    <Config Name="Service Port" Target="5101" Default="5101" Mode="tcp" Description="Allow external clients to connect to server" Type="Port" Display="always-hide" Required="false" Mask="false">5101</Config>
     <Config Name="Library" Target="/library" Default="" Mode="rw" Description="Library of games" Type="Path" Display="always-hide" Required="true" Mask="false"/>
     <Config Name="Config data" Target="/config" Default="/mnt/user/appdata/retrom/config" Mode="rw" Description="Config data for application" Type="Path" Display="advanced-hide" Required="true" Mask="false">/mnt/user/appdata/retrom/config</Config>
 </Container>

--- a/templates/rtsp_to_web.xml
+++ b/templates/rtsp_to_web.xml
@@ -29,6 +29,6 @@
     <Requires>
         This application expects a `config.json` file to be mounted at the Config Data path. See example: https://github.com/deepch/RTSPtoWeb?tab=readme-ov-file#example-configjson
     </Requires>
-    <Config Name="Web UI Port" Target="8083" Default="8083" Mode="tcp" Description="Container Port: 8083" Type="Port" Display="always-hide" Required="true" Mask="false">8083</Config>
+    <Config Name="Web UI Port" Target="8083" Default="8083" Mode="tcp" Description="Container Port: 8083" Type="Port" Display="always-hide" Required="false" Mask="false">8083</Config>
     <Config Name="Config data" Target="/config/config.json" Default="/mnt/user/appdata/rtsp_to_web/config.json" Mode="rw" Description="Config data for application" Type="Path" Display="advanced-hide" Required="true" Mask="false">/mnt/user/appdata/rtsp_to_web/config.json</Config>
 </Container>

--- a/templates/scriberr.xml
+++ b/templates/scriberr.xml
@@ -33,7 +33,7 @@
         [br]
         On first load, app will throw a 500 error due to missing database. Simply reload the page.
     </Requires>
-    <Config Name="Web UI Port" Target="3000" Default="3000" Mode="tcp" Description="Container Port: 3000" Type="Port" Display="always-hide" Required="true" Mask="false">3000</Config>
+    <Config Name="Web UI Port" Target="3000" Default="3000" Mode="tcp" Description="Container Port: 3000" Type="Port" Display="always-hide" Required="false" Mask="false">3000</Config>
     <Config Name="Database UI Port" Target="8080" Default="8080" Mode="tcp" Description="Expose database UI (optional)" Type="Port" Display="always" Required="false" Mask="false">8080</Config>
     <Config Name="JobQueue UI Port" Target="9243" Default="9243" Mode="tcp" Description="Expose job queue UI (optional)" Type="Port" Display="always" Required="false" Mask="false">9243</Config>
     <Config Name="OpenAI API Key" Target="OPENAI_API_KEY" Default="" Description="OpenAI API key" Type="Variable" Display="always-hide" Required="true" Mask="true"/>

--- a/templates/serveo_server.xml
+++ b/templates/serveo_server.xml
@@ -31,9 +31,9 @@
         Initial release
     </Changes>
     <PostArgs>serveo -port=22 -http_port=80 -https_port=443 -private_key_path=/root/.ssh/id_ed25519 -cert_dir=/certs -domain $DOMAIN</PostArgs>
-    <Config Name="HTTP Traffic Port" Target="80" Default="1080" Mode="tcp" Description="Container Port: 80" Type="Port" Display="always-hide" Required="true" Mask="false">1080</Config>
-    <Config Name="HTTPS Traffic Port" Target="443" Default="10443" Mode="tcp" Description="Container Port: 443" Type="Port" Display="always-hide" Required="true" Mask="false">10443</Config>
-    <Config Name="SSH Port" Target="22" Default="2222" Mode="tcp" Description="Container Port: 22" Type="Port" Display="always-hide" Required="true" Mask="false">2222</Config>
+    <Config Name="HTTP Traffic Port" Target="80" Default="1080" Mode="tcp" Description="Container Port: 80" Type="Port" Display="always-hide" Required="false" Mask="false">1080</Config>
+    <Config Name="HTTPS Traffic Port" Target="443" Default="10443" Mode="tcp" Description="Container Port: 443" Type="Port" Display="always-hide" Required="false" Mask="false">10443</Config>
+    <Config Name="SSH Port" Target="22" Default="2222" Mode="tcp" Description="Container Port: 22" Type="Port" Display="always-hide" Required="false" Mask="false">2222</Config>
     <Config Name="LetsEncrypt Certificate" Target="/certs/letsencrypt.crt" Default="" Description="Path to LetsEncrypt 'fullchain.pem' file" Type="Path" Display="always" Required="true" Mask="false"/>
     <Config Name="LetsEncrypt Private Key" Target="/certs/letsencrypt.key" Default="" Description="Path to LetsEncrypt 'privkey.pem' file" Type="Path" Display="always" Required="true" Mask="false"/>
     <Config Name="SSH Config" Target="/root/.ssh" Default="" Description="Path to SSH config directory" Type="Path" Display="always" Required="true" Mask="false"/>

--- a/templates/soft_serve.xml
+++ b/templates/soft_serve.xml
@@ -32,9 +32,9 @@
 
         Initial release
     </Changes>
-    <Config Name="SSH Port" Target="23231" Default="" Mode="tcp" Description="Container Port: 23231" Type="Port" Display="always" Required="true" Mask="false">23231</Config>
-    <Config Target="23232" Default="" Mode="tcp" Description="Container Port: 23232" Type="Port" Display="always" Required="true" Mask="false">23232</Config>
-    <Config Target="23233" Default="" Mode="tcp" Description="Container Port: 23233" Type="Port" Display="always" Required="true" Mask="false">23233</Config>
-    <Config Target="9418" Default="" Mode="tcp" Description="Container Port: 9418" Type="Port" Display="always" Required="true" Mask="false">9418</Config>
+    <Config Name="SSH Port" Target="23231" Default="" Mode="tcp" Description="Container Port: 23231" Type="Port" Display="always" Required="false" Mask="false">23231</Config>
+    <Config Target="23232" Default="" Mode="tcp" Description="Container Port: 23232" Type="Port" Display="always" Required="false" Mask="false">23232</Config>
+    <Config Target="23233" Default="" Mode="tcp" Description="Container Port: 23233" Type="Port" Display="always" Required="false" Mask="false">23233</Config>
+    <Config Target="9418" Default="" Mode="tcp" Description="Container Port: 9418" Type="Port" Display="always" Required="false" Mask="false">9418</Config>
     <Config Name="Data Path" Target="/soft-serve" Default="/mnt/user/appdata/softserve" Mode="rw" Description="Storage for config file, databases and repos" Type="Path" Display="advanced" Required="true" Mask="false">/mnt/user/appdata/softserve</Config>
 </Container>

--- a/templates/subs.xml
+++ b/templates/subs.xml
@@ -27,7 +27,7 @@
 
         Initial release
     </Changes>
-    <Config Name="Web UI Port" Target="3000" Default="3000" Mode="tcp" Description="Container Port: 3000" Type="Port" Display="always-hide" Required="true" Mask="false">3000</Config>
+    <Config Name="Web UI Port" Target="3000" Default="3000" Mode="tcp" Description="Container Port: 3000" Type="Port" Display="always-hide" Required="false" Mask="false">3000</Config>
     <Config Name="Database Path" Target="/database" Default="/mnt/user/appdata/subs/database" Mode="rw" Description="Database directory" Type="Path" Display="advanced-hide" Required="true" Mask="false">/mnt/user/appdata/subs/database</Config>
     <Config Name="Database URL" Target="DATABASE_URL" Default="file:/database/db.sqlite" Description="Internal database URL" Type="Variable" Display="advanced-hide" Required="true" Mask="false">file:/database/db.sqlite</Config>
     <Config Name="Use KV Database" Target="NEXT_PUBLIC_USE_SQLITE" Default="false|true" Description="Use KV database instead of localStorage" Type="Variable" Display="advanced-hide" Required="true" Mask="false"/>

--- a/templates/terraform_http_backend.xml
+++ b/templates/terraform_http_backend.xml
@@ -25,5 +25,5 @@
 
         Initial release
     </Changes>
-    <Config Name="Server Port" Target="8080" Default="8080" Mode="tcp" Description="Container Port: 8080" Type="Port" Display="always" Required="true" Mask="false">8080</Config>
+    <Config Name="Server Port" Target="8080" Default="8080" Mode="tcp" Description="Container Port: 8080" Type="Port" Display="always" Required="false" Mask="false">8080</Config>
 </Container>

--- a/templates/threadfin.xml
+++ b/templates/threadfin.xml
@@ -39,7 +39,7 @@
 
         Initial release
     </Changes>
-    <Config Name="Web UI Port" Target="34400" Default="34400" Mode="tcp" Description="Container Port: 34400" Type="Port" Display="always" Required="true" Mask="false">34400</Config>
+    <Config Name="Web UI Port" Target="34400" Default="34400" Mode="tcp" Description="Container Port: 34400" Type="Port" Display="always" Required="false" Mask="false">34400</Config>
     <Config Name="Configuration data" Target="/home/threadfin/conf" Default="/mnt/user/appdata/threadfin/config" Mode="rw" Description="Path to configuration data" Type="Path" Display="advanced" Required="true" Mask="false">/mnt/user/appdata/threadfin/config</Config>
     <Config Name="Temporary data" Target="/tmp/threadfin" Default="/mnt/user/appdata/threadfin/temp" Mode="rw" Description="Path to temporary data" Type="Path" Display="advanced" Required="true" Mask="false">/mnt/user/appdata/threadfin/temp</Config>
     <Config Name="PUID" Target="PUID" Default="1001" Description="" Type="Variable" Display="advanced" Required="true" Mask="false">1001</Config>

--- a/templates/traefik_shaper.xml
+++ b/templates/traefik_shaper.xml
@@ -28,7 +28,7 @@
     <Requires>
         Expects a dynamic whitelist YAML file at the "Whitelist File" path.
     </Requires>
-    <Config Name="App Port" Target="5000" Default="5000" Mode="tcp" Description="Container Port: 5000" Type="Port" Display="always-hide" Required="true" Mask="false">5000</Config>
+    <Config Name="App Port" Target="5000" Default="5000" Mode="tcp" Description="Container Port: 5000" Type="Port" Display="always-hide" Required="false" Mask="false">5000</Config>
 
     <Config Name="App URL" Target="APPURL" Default="http://localhost:5000" Description="URL of the app. Replace with domain (ex. https://traefikshaper.example.com)" Type="Variable" Display="always-hide" Required="true" Mask="false">http://localhost:5000</Config>
     <Config Name="Access Request Endpoint" Target="GRANT_HTTP_ENDPOINT" Default="" Description="Endpoint for clients to request access (ex. /knock-knock)" Type="Variable" Display="always-hide" Required="true" Mask="false"/>

--- a/templates/tunarr.xml
+++ b/templates/tunarr.xml
@@ -76,7 +76,7 @@
     <Requires>
         Don't forget to add Nvidia- or Intel-specific parameters for hardware transcoding. Enable **Advanced View** and see **Overview** for details.
     </Requires>
-    <Config Name="Web UI Port" Target="8000" Default="8000" Mode="tcp" Description="Container Port: 8000" Type="Port" Display="always" Required="true" Mask="false">8000</Config>
+    <Config Name="Web UI Port" Target="8000" Default="8000" Mode="tcp" Description="Container Port: 8000" Type="Port" Display="always" Required="false" Mask="false">8000</Config>
     <Config Name="Configuration data" Target="/config/tunarr" Default="/mnt/user/appdata/tunarr/config" Mode="rw" Description="Path to configuration data" Type="Path" Display="advanced" Required="true" Mask="false">/mnt/user/appdata/tunarr/config</Config>
     <Config Name="dizqueTV migration data" Target="/.dizquetv" Default="" Mode="ro" Description="Path to old dizqueTV installation for migration" Type="Path" Display="advanced" Required="false" Mask="false" />
     <Config Name="Nvidia Visible Devices" Target="NVIDIA_VISIBLE_DEVICES" Default="all" Mode="" Description="Nvidia Visible Devices (Optional - Requires Nvidia GPU and Unraid Nvidia build)" Type="Variable" Display="always-hide" Required="false" Mask="false"/>

--- a/templates/vhs.xml
+++ b/templates/vhs.xml
@@ -30,5 +30,5 @@
 
         Initial release (v0.7.2+)
     </Changes>
-    <Config Name="SSH Port" Target="1976" Default="" Mode="tcp" Description="Container Port: 1976" Type="Port" Display="always" Required="true" Mask="false">1976</Config>
+    <Config Name="SSH Port" Target="1976" Default="" Mode="tcp" Description="Container Port: 1976" Type="Port" Display="always" Required="false" Mask="false">1976</Config>
 </Container>

--- a/templates/weatherstar.xml
+++ b/templates/weatherstar.xml
@@ -25,5 +25,5 @@
 
         Initial release
     </Changes>
-    <Config Name="WebUI" Target="8080" Default="8080" Mode="tcp" Description="Container Port: 8080" Type="Port" Display="always" Required="true" Mask="false">8080</Config>
+    <Config Name="WebUI" Target="8080" Default="8080" Mode="tcp" Description="Container Port: 8080" Type="Port" Display="always" Required="false" Mask="false">8080</Config>
 </Container>

--- a/templates/webhook_site_backend.xml
+++ b/templates/webhook_site_backend.xml
@@ -28,7 +28,7 @@
 
         Initial release
     </Changes>
-    <Config Name="Server Port" Target="6001" Default="6001" Mode="tcp" Description="Container Port: 6001" Type="Port" Display="always-hide" Required="true" Mask="false">6001</Config>
+    <Config Name="Server Port" Target="6001" Default="6001" Mode="tcp" Description="Container Port: 6001" Type="Port" Display="always-hide" Required="false" Mask="false">6001</Config>
     <Config Name="Frontend URL" Target="LARAVEL_ECHO_SERVER_AUTH_HOST" Default="http://localhost" Description="Frontend URL. Replace with IP and port of the frontend." Type="Variable" Display="always-hide" Required="true" Mask="false">http://localhost</Config>
     <Config Name="Redis Host" Target="ECHO_REDIS_HOSTNAME" Default="localhost" Description="Redis host. Replace with IP address of Redis server." Type="Variable" Display="always-hide" Required="true" Mask="false"/>
     <Config Name="Redis Port" Target="ECHO_REDIS_PORT" Default="6379" Description="Redis port" Type="Variable" Display="always-hide" Required="true" Mask="false">6379</Config>

--- a/templates/webhook_site_frontend.xml
+++ b/templates/webhook_site_frontend.xml
@@ -34,7 +34,7 @@
         Initial release
     </Changes>
     <PostArgs>php artisan queue:work --daemon --tries=3 --timeout=10"</PostArgs>
-    <Config Name="Web UI Port" Target="80" Default="8084" Mode="tcp" Description="Container Port: 80" Type="Port" Display="always-hide" Required="true" Mask="false">8084</Config>
+    <Config Name="Web UI Port" Target="80" Default="8084" Mode="tcp" Description="Container Port: 80" Type="Port" Display="always-hide" Required="false" Mask="false">8084</Config>
     <Config Name="Server Host" Target="BACKEND_SERVER_HOST" Default="localhost" Description="Hostname for the backend server. Replace with IP address of the backend server." Type="Variable" Display="always-hide" Required="true" Mask="false"/>
     <Config Name="Server Port" Target="BACKEND_SERVER_PORT" Default="6001" Description="Port for the backend server" Type="Variable" Display="always-hide" Required="true" Mask="false">6001</Config>
     <Config Name="App URL" Target="APP_URL" Default="http://localhost:8084" Description="Application URL. Replace with IP and port. Port must match Web UI Port" Type="Variable" Display="always-hide" Required="true" Mask="false">http://localhost:8084</Config>

--- a/templates/webtrees.xml
+++ b/templates/webtrees.xml
@@ -32,7 +32,7 @@
 
         Initial release
     </Changes>
-    <Config Name="WebUI" Target="80" Default="8079" Mode="tcp" Description="Container Port: 80" Type="Port" Display="always" Required="true" Mask="false">8079</Config>
+    <Config Name="WebUI" Target="80" Default="8079" Mode="tcp" Description="Container Port: 80" Type="Port" Display="always" Required="false" Mask="false">8079</Config>
     <Config Name="Database host" Target="DB_HOST" Default="localhost" Description="Database Hostname" Type="Variable" Display="always" Required="true" Mask="false"/>
     <Config Name="Database port" Target="DB_PORT" Default="3306" Description="Database Port" Type="Variable" Display="always" Required="true" Mask="false"/>
     <Config Name="Database user" Target="DB_USER" Default="" Description="Database Username" Type="Variable" Display="always" Required="true" Mask="false"/>

--- a/templates/yamtrack.xml
+++ b/templates/yamtrack.xml
@@ -33,7 +33,7 @@
 
         Initial release
     </Changes>
-    <Config Name="WebUI" Target="8000" Default="8000" Mode="tcp" Description="Container Port: 8000" Type="Port" Display="always" Required="true" Mask="false">8000</Config>
+    <Config Name="WebUI" Target="8000" Default="8000" Mode="tcp" Description="Container Port: 8000" Type="Port" Display="always" Required="false" Mask="false">8000</Config>
     <Config Name="Secret" Target="SECRET" Default="" Description="Secret key for the application" Type="Variable" Display="always" Required="true" Mask="true"/>
     <Config Name="Redis Host" Target="REDIS_URL" Default="redis://localhost:6379" Description="Redis connection details" Type="Variable" Display="always" Required="true" Mask="false"/>
     <Config Name="TMDb API key" Target="TMDB_API" Default="" Description="Override default The Movie Database API key" Type="Variable" Display="advanced" Required="false" Mask="true"/>


### PR DESCRIPTION
There are some cases where we don't want to expose ports on the host machine network:
* Reduce attack surface
* Block access to unused protocols/services
* Using reverse proxy
* Connectivity only required between containers within a private docker network

Due to this, it's very interesting to have all ports be an optional parameter instead of a requirement.