### PR TITLE
postiz: Simplify default installation options to use port: 5000 (internal proxy) & storage provider: local.

### DIFF
--- a/templates/postiz.xml
+++ b/templates/postiz.xml
@@ -8,7 +8,7 @@
         <TagDescription>Latest stable release</TagDescription>
     </Branch>
     <Network>bridge</Network>
-    <WebUI>http://[IP]:[PORT:4200]</WebUI>
+    <WebUI>http://[IP]:[PORT:5000]</WebUI>
     <Privileged>false</Privileged>
     <Support>https://github.com/gitroomhq/postiz-app/issues</Support>
     <Project>https://postiz.com/</Project>
@@ -19,7 +19,11 @@
     <Maintainer>
         <WebPage>https://github.com/nwithan8</WebPage>
     </Maintainer>
-    <Changes>
+	<Changes>
+		### 2024-11-01
+
+		Simplify template to use the Postiz internal proxy.
+
         ### 2024-09-23
 
         Initial release
@@ -27,20 +31,21 @@
     <Requires>
         Requires separate Postgres and Redis databases. See documentation for more information: https://docs.postiz.com/installation/docker-compose#example-docker-composeyml-file
     </Requires>
-    <Config Name="Web UI Port" Target="4200" Default="4200" Mode="tcp" Description="Container Port: 4200" Type="Port" Display="always" Required="true" Mask="false">4200</Config>
-    <Config Name="Backend Port" Target="3000" Default="3000" Mode="tcp" Description="Container Port: 3000" Type="Port" Display="always" Required="true" Mask="false">3000</Config>
-    <Config Name="Web UI URL" Target="MAIN_URL" Default="https://SERVER_IP_ADDRESS:4200" Description="The public URL to the Postiz Web UI. Provide server IP address." Type="Variable" Display="always" Required="true" Mask="false">https://SERVER_IP_ADDRESS:4200</Config>
-    <Config Name="Public Frontend URL" Target="FRONTEND_URL" Default="https://SERVER_IP_ADDRESS:4200" Description="The public URL to the Postiz frontend. Same as Web UI URL." Type="Variable" Display="always" Required="true" Mask="false">https://SERVER_IP_ADDRESS:4200</Config>
-    <Config Name="Public Backend URL" Target="NEXT_PUBLIC_BACKEND_URL" Default="https://SERVER_IP_ADDRESS:3000" Description="The public URL to the Postiz backend. Provide server IP address." Type="Variable" Display="always" Required="true" Mask="false">https://SERVER_IP_ADDRESS:3000</Config>
+    <Config Name="Frontend Port" Target="5000" Default="5000" Mode="tcp" Description="Container Port: 5000" Type="Port" Display="always" Required="true" Mask="false">5000</Config>
+    <Config Name="Web UI URL" Target="MAIN_URL" Default="https://SERVER_IP_ADDRESS:5000" Description="The public URL to the Postiz Web UI. Provide server IP address." Type="Variable" Display="always" Required="true" Mask="false">https://SERVER_IP_ADDRESS:5000</Config>
+    <Config Name="Public Frontend URL" Target="FRONTEND_URL" Default="https://SERVER_IP_ADDRESS:5000" Description="The public URL to the Postiz frontend. Same as Web UI URL." Type="Variable" Display="always" Required="true" Mask="false">https://SERVER_IP_ADDRESS:5000</Config>
+	<Config Name="Public Backend URL" Target="NEXT_PUBLIC_BACKEND_URL" Default="https://SERVER_IP_ADDRESS:5000/api" Description="The public URL to the Postiz backend. Provide server IP address." Type="Variable" Display="always" Required="true" Mask="false">https://SERVER_IP_ADDRESS:5000/api</Config>
     <Config Name="JWT Secret" Target="JWT_SECRET" Default="" Description="JWT token used for encryption. Generate with `openssl rand -base64 32`" Type="Variable" Display="always" Required="true" Mask="true"/>
     <Config Name="Postgres Database URL" Target="DATABASE_URL" Default="postgresql://USERNAME:PASSWORD@IP:5432/DATABASE_NAME" Description="Connection URL for Postgres database" Type="Variable" Display="always" Required="true" Mask="false"/>
     <Config Name="Redis Database URL" Target="REDIS_URL" Default="redis://localhost:6379" Description="Connection URL for Postgres database" Type="Variable" Display="always" Required="true" Mask="false"/>
-    <Config Name="Cloudflare Account ID" Target="CLOUDFLARE_ACCOUNT_ID" Default="" Description="Cloudflare account ID" Type="Variable" Display="always" Required="true" Mask="false"/>
-    <Config Name="Cloudflare Access Key" Target="CLOUDFLARE_ACCESS_KEY" Default="" Description="Cloudflare access key" Type="Variable" Display="always" Required="true" Mask="true"/>
-    <Config Name="Cloudflare Access Key Secret" Target="CLOUDFLARE_SECRET_ACCESS_KEY" Default="" Description="Cloudflare access key secret" Type="Variable" Display="always" Required="true" Mask="true"/>
-    <Config Name="Cloudflare Bucket Name" Target="CLOUDFLARE_BUCKETNAME" Default="postiz" Description="Cloudflare bucket name" Type="Variable" Display="always" Required="true" Mask="false">postiz</Config>
-    <Config Name="Cloudflare Bucket URL" Target="CLOUDFLARE_BUCKET_URL" Default="" Description="Cloudflare bucket URL" Type="Variable" Display="always" Required="true" Mask="false"/>
-    <Config Name="Cloudflare Region" Target="CLOUDFLARE_REGION" Default="auto" Description="Cloudflare region" Type="Variable" Display="always" Required="true" Mask="false">auto</Config>
+	<Config Name="Storage Provider" Target="STORAGE_PROVIDER" Default="local" Description="Storage provider for Postiz" Type="Variable" Display="always" Required="true" Mask="false">local</Config>
+	<Config Name="Upload Directory" TARGET="UPLOAD_DIR" Default="/uploads" Description="Directory for uploads" Type="Variable" Display="always" Required="true" Mask="false">/uploads</Config>
+    <Config Name="Cloudflare Account ID" Target="CLOUDFLARE_ACCOUNT_ID" Default="" Description="Cloudflare account ID" Type="Variable" Display="always" Required="false" Mask="false"/>
+    <Config Name="Cloudflare Access Key" Target="CLOUDFLARE_ACCESS_KEY" Default="" Description="Cloudflare access key" Type="Variable" Display="always" Required="false" Mask="true"/>
+    <Config Name="Cloudflare Access Key Secret" Target="CLOUDFLARE_SECRET_ACCESS_KEY" Default="" Description="Cloudflare access key secret" Type="Variable" Display="always" Required="false" Mask="true"/>
+    <Config Name="Cloudflare Bucket Name" Target="CLOUDFLARE_BUCKETNAME" Default="postiz" Description="Cloudflare bucket name" Type="Variable" Display="always" Required="false" Mask="false">postiz</Config>
+    <Config Name="Cloudflare Bucket URL" Target="CLOUDFLARE_BUCKET_URL" Default="" Description="Cloudflare bucket URL" Type="Variable" Display="always" Required="false" Mask="false"/>
+    <Config Name="Cloudflare Region" Target="CLOUDFLARE_REGION" Default="auto" Description="Cloudflare region" Type="Variable" Display="always" Required="false" Mask="false">auto</Config>
     <Config Name="Twitter/X Client ID" Target="X_CLIENT" Default="" Description="Client ID for Twitter/X" Type="Variable" Display="always" Required="false" Mask="true"/>
     <Config Name="Twitter/X Client Secret" Target="X_SECRET" Default="" Description="Client secret for Twitter/X" Type="Variable" Display="always" Required="false" Mask="true"/>
     <Config Name="Twitter/X API Key" Target="X_API_KEY" Default="" Description="API key for Twitter/X" Type="Variable" Display="always" Required="false" Mask="true"/>


### PR DESCRIPTION
This change sets the Postiz template to use the Port 5000 internal proxy by default, which is far less error prone then getting the URLs correct with the backend and frontend running on ports 4200 and 3000 respectively.

This change also sets teh default storage provider to "local", now that CloudFlare is optional.

I don't have an unraid installation to test this against, unfortunately. However I did run xmllint at least. 