### PR TITLE
pinepods: Fixes possibly incorrect and missing env vars

### DIFF
--- a/templates/pinepods.xml
+++ b/templates/pinepods.xml
@@ -43,6 +43,7 @@
     <Config Name="Database - Password" Target="DB_PASS" Default="" Description="Password for database" Type="Variable" Display="always-hide" Required="true" Mask="true"/>
     <Config Name="Downloads Path" Target="/opt/pinepods/downloads" Default="/mnt/user/appdata/pinepods/downloads" Mode="rw" Description="Path to downloads folder" Type="Path" Display="advanced-hide" Required="true" Mask="false"/>
     <Config Name="Search API URL" Target="SEARCH_API_URL" Default="https://search.pinepods.online/api/search" Description="URL of podcast search API" Type="Variable" Display="advanced-hide" Required="true" Mask="false">https://search.pinepods.online/api/search</Config>
+    <Config Name="People API URL" Target="PEOPLE_API_URL" Default="https://people.pinepods.online" Description="URL of people API" Type="Variable" Display="advanced-hide" Required="true" Mask="false">https://people.pinepods.online</Config>
     <Config Name="Debug Mode" Target="DEBUG" Default="False|True" Description="Enable debug mode" Type="Variable" Display="advanced-hide" Required="true" Mask="false"/>
     <Config Name="Backups Path" Target="/opt/pinepods/backups" Default="/mnt/user/appdata/pinepods/backups" Mode="rw" Description="Path to backups folder" Type="Path" Display="advanced-hide" Required="true" Mask="false"/>
 </Container>

--- a/templates/pinepods.xml
+++ b/templates/pinepods.xml
@@ -40,7 +40,7 @@
     <Config Name="Database - Port" Target="DB_PORT" Default="" Description="Port of database" Type="Variable" Display="always-hide" Required="true" Mask="false"/>
     <Config Name="Database - Name" Target="DB_NAME" Default="" Description="Name of database" Type="Variable" Display="always-hide" Required="true" Mask="false"/>
     <Config Name="Database - Username" Target="DB_USER" Default="" Description="Username for database" Type="Variable" Display="always-hide" Required="true" Mask="false"/>
-    <Config Name="Database - Password" Target="DB_PASS" Default="" Description="Password for database" Type="Variable" Display="always-hide" Required="true" Mask="true"/>
+    <Config Name="Database - Password" Target="DB_PASSWORD" Default="" Description="Password for database" Type="Variable" Display="always-hide" Required="true" Mask="true"/>
     <Config Name="Downloads Path" Target="/opt/pinepods/downloads" Default="/mnt/user/appdata/pinepods/downloads" Mode="rw" Description="Path to downloads folder" Type="Path" Display="advanced-hide" Required="true" Mask="false"/>
     <Config Name="Search API URL" Target="SEARCH_API_URL" Default="https://search.pinepods.online/api/search" Description="URL of podcast search API" Type="Variable" Display="advanced-hide" Required="true" Mask="false">https://search.pinepods.online/api/search</Config>
     <Config Name="People API URL" Target="PEOPLE_API_URL" Default="https://people.pinepods.online" Description="URL of people API" Type="Variable" Display="advanced-hide" Required="true" Mask="false">https://people.pinepods.online</Config>


### PR DESCRIPTION
Tried spinning this up today and noticed that the container kept stopping in unRAID. With debug mode set to True, I was able to deduce that the [PEOPLE_API_URL](https://www.pinepods.online/docs/intro#:~:text=PEOPLE_API_URL:%20'https://people.pinepods.online') value was not set in the template based on the following error:
```
Error: Unexpected end of key/value pairs in value 'DB_TYPE=postgresql,SEARCH_API_URL=https://search.pinepods.online/api/search,PEOPLE_API_URL=,DEBUG_MODE=False' in section 'program:client_api' (file: '/pinepods/startup/supervisord.conf')
```

Also fixes the [possibly incorrect](https://github.com/madeofpendletonwool/PinePods?tab=readme-ov-file#:~:text=DB_PASSWORD:%20myS3curepass) `DB_PASS` variable to be `DB_PASSWORD` which is what the app is expecting.